### PR TITLE
1.18 - Quest changes, npc titles and eye level fix

### DIFF
--- a/src/main/java/flash/npcmod/ClientProxy.java
+++ b/src/main/java/flash/npcmod/ClientProxy.java
@@ -203,7 +203,7 @@ public class ClientProxy extends CommonProxy {
           QuestInstance.TurnInType turnInType = QuestInstance.TurnInType.values()[buf.readInt()];
           Quest quest = ClientQuestUtil.fromName(questName);
           if (quest != null) {
-            acceptedQuests.add(new QuestInstance(quest, pickedUpFrom, pickedUpFromName, turnInType, minecraft.player));
+            acceptedQuests.add(new QuestInstance(quest, pickedUpFrom, pickedUpFromName, turnInType, minecraft.player, false));
             for (int j = 0; j < quest.getObjectives().size(); j++) {
               int id = buf.readInt();
               for (int k = 0; k < quest.getObjectives().size(); k++) {

--- a/src/main/java/flash/npcmod/ClientProxy.java
+++ b/src/main/java/flash/npcmod/ClientProxy.java
@@ -139,14 +139,14 @@ public class ClientProxy extends CommonProxy {
   }
 
 
-  public void acceptQuest(String name, int entityid) {
+  public void acceptQuest(String name, int entityid, QuestInstance.TurnInType turnInType, UUID uuid) {
     PacketDispatcher.sendToServer(new CRequestQuestInfo(name));
     Quest quest = ClientQuestUtil.fromName(name);
     Entity entity = minecraft.player.level.getEntity(entityid);
     if (quest != null && entity instanceof NpcEntity) {
       IQuestCapability capability = QuestCapabilityProvider.getCapability(minecraft.player);
 
-      QuestInstance questInstance = new QuestInstance(quest, entity.getUUID(), entity.getName().getString(), minecraft.player);
+      QuestInstance questInstance = new QuestInstance(quest, uuid, entity.getName().getString(), turnInType, minecraft.player);
       capability.acceptQuest(questInstance);
     }
   }
@@ -200,9 +200,10 @@ public class ClientProxy extends CommonProxy {
           String questName = buf.readUtf(51);
           UUID pickedUpFrom = buf.readUUID();
           String pickedUpFromName = buf.readUtf(200);
+          QuestInstance.TurnInType turnInType = QuestInstance.TurnInType.values()[buf.readInt()];
           Quest quest = ClientQuestUtil.fromName(questName);
           if (quest != null) {
-            acceptedQuests.add(new QuestInstance(quest, pickedUpFrom, pickedUpFromName, minecraft.player));
+            acceptedQuests.add(new QuestInstance(quest, pickedUpFrom, pickedUpFromName, turnInType, minecraft.player));
             for (int j = 0; j < quest.getObjectives().size(); j++) {
               int id = buf.readInt();
               for (int k = 0; k < quest.getObjectives().size(); k++) {

--- a/src/main/java/flash/npcmod/CommonProxy.java
+++ b/src/main/java/flash/npcmod/CommonProxy.java
@@ -34,7 +34,7 @@ public class CommonProxy {
   public void syncCompletedQuests(ArrayList<String> completedQuests) {}
   public void syncQuestProgressMap(Map<QuestObjective, Integer> progressMap) {}
 
-  public void acceptQuest(String name, int entityid) {}
+  public void acceptQuest(String name, int entityid, QuestInstance.TurnInType turnInType, UUID uuid) {}
   public void completeQuest(String name, UUID uuid) {}
 
   public Player getPlayer() {

--- a/src/main/java/flash/npcmod/capability/quests/IQuestCapability.java
+++ b/src/main/java/flash/npcmod/capability/quests/IQuestCapability.java
@@ -23,5 +23,6 @@ public interface IQuestCapability extends INBTSerializable<CompoundTag> {
   void acceptQuest(QuestInstance quest);
   void completeQuest(QuestInstance quest);
   void abandonQuest(QuestInstance quest);
+  void resetAllQuestProgress();
 
 }

--- a/src/main/java/flash/npcmod/capability/quests/QuestCapability.java
+++ b/src/main/java/flash/npcmod/capability/quests/QuestCapability.java
@@ -96,7 +96,7 @@ public class QuestCapability implements IQuestCapability {
   public void completeQuest(QuestInstance quest) {
     if (acceptedQuests.contains(quest)) {
       if (quest.getQuest().canComplete()) {
-        quest.getQuest().complete(quest.getPlayer(), quest.getPickedUpFrom(), quest.getPickedUpFromName());
+        quest.getQuest().complete(quest.getPlayer(), quest.getPickedUpFrom(), quest.getPickedUpFromName(), quest.getTurnInType());
 
         abandonQuest(quest);
 
@@ -163,6 +163,7 @@ public class QuestCapability implements IQuestCapability {
       tag2.putString("quest", quest.getQuest().getName());
       tag2.putUUID("uuid", quest.getPickedUpFrom());
       tag2.putString("npcname", quest.getPickedUpFromName());
+      tag2.putInt("turnintype", quest.getTurnInType().ordinal());
       acceptedQuests.add(tag2);
     });
     tag.put("acceptedQuests", acceptedQuests);
@@ -195,8 +196,12 @@ public class QuestCapability implements IQuestCapability {
     for (int i = 0; i < acceptedQuestsTag.size(); i++) {
       CompoundTag tag2 = acceptedQuestsTag.getCompound(i);
       Quest quest = CommonQuestUtil.fromName(tag2.getString("quest"));
+      QuestInstance.TurnInType turnInType = QuestInstance.TurnInType.QuestGiver;
+      try {
+        turnInType = QuestInstance.TurnInType.values()[tag2.getInt("turnintype")];
+      } catch (Exception ignored) {}
       if (quest != null)
-        acceptedQuests.add(new QuestInstance(quest, tag2.getUUID("uuid"), tag2.getString("npcname")));
+        acceptedQuests.add(new QuestInstance(quest, tag2.getUUID("uuid"), tag2.getString("npcname"), turnInType));
     }
     setAcceptedQuests(acceptedQuests);
 

--- a/src/main/java/flash/npcmod/capability/quests/QuestCapability.java
+++ b/src/main/java/flash/npcmod/capability/quests/QuestCapability.java
@@ -136,6 +136,14 @@ public class QuestCapability implements IQuestCapability {
     }
   }
 
+  @Override
+  public void resetAllQuestProgress() {
+    trackedQuest = "";
+    acceptedQuests.clear();
+    completedQuests.clear();
+    questProgressMap.clear();
+  }
+
   private String objectiveToString(QuestObjective objective) {
     return objective.getQuest().getName()+":::"+objective.getName();
   }

--- a/src/main/java/flash/npcmod/client/gui/screen/NpcBuilderScreen.java
+++ b/src/main/java/flash/npcmod/client/gui/screen/NpcBuilderScreen.java
@@ -303,6 +303,8 @@ public class NpcBuilderScreen extends Screen {
     this.rendererTagField = this.addRenderableWidget(new EditBox(font, minX + 125, 80, 165, 20, TextComponent.EMPTY));
     this.rendererTagField.setResponder(this::setRendererTag);
     this.rendererTagField.setMaxLength(1000);
+    if (currentData.rendererTag.contains("id"))
+      currentData.rendererTag.remove("id");
     this.rendererTagField.setValue(currentData.rendererTag.getAsString());
   }
 

--- a/src/main/java/flash/npcmod/client/gui/screen/NpcBuilderScreen.java
+++ b/src/main/java/flash/npcmod/client/gui/screen/NpcBuilderScreen.java
@@ -13,6 +13,7 @@ import flash.npcmod.init.EntityInit;
 import flash.npcmod.network.PacketDispatcher;
 import flash.npcmod.network.packets.client.CEditNpc;
 import flash.npcmod.network.packets.client.CRequestContainer;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Checkbox;
 import net.minecraft.client.gui.components.EditBox;
@@ -20,7 +21,10 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.TagParser;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.ComponentUtils;
 import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.EntityType;
@@ -41,6 +45,7 @@ public class NpcBuilderScreen extends Screen {
   private static class NpcData {
 
     private String name;
+    private String title;
     private String dialogue;
     private String behavior;
     private int textColor;
@@ -57,6 +62,7 @@ public class NpcBuilderScreen extends Screen {
 
       data.pose = npcEntity.isCrouching() ? CEditNpc.NPCPose.CROUCHING : npcEntity.isSitting() ? CEditNpc.NPCPose.SITTING : CEditNpc.NPCPose.STANDING;
       data.name = npcEntity.getName().getString();
+      data.title = npcEntity.getTitle();
       data.isNameVisible = npcEntity.isCustomNameVisible();
       data.texture = npcEntity.getTexture();
       data.isTextureResourceLocation = npcEntity.isTextureResourceLocation();
@@ -84,6 +90,7 @@ public class NpcBuilderScreen extends Screen {
       }
       npcEntity.setCustomName(new TextComponent(name));
       npcEntity.setCustomNameVisible(isNameVisible);
+      npcEntity.setTitle(title);
       npcEntity.setTexture(texture);
       npcEntity.setIsTextureResourceLocation(isTextureResourceLocation);
       npcEntity.setSlim(isSlim);
@@ -164,13 +171,21 @@ public class NpcBuilderScreen extends Screen {
     this.b = ColorUtil.hexToB(currentData.textColor);
   }
 
+  private static int max(int... numbers) {
+    int max = numbers[0];
+    for (int i = 1; i < numbers.length; i++)
+      if (numbers[i] > max)
+        max = numbers[i];
+    return max;
+  }
+
   @Override
   protected void init() {
-    minX = 5 + Math.max(
-        Math.max(
-            Math.max(font.width("Name: "), font.width("Texture: ")),
-            Math.max(font.width("Dialogue: "), font.width("Text Color: "))),
-        font.width("Behavior: ")    );
+    minX = 5 + max(
+            font.width("Name: "), font.width("Texture: "),
+            font.width("Dialogue: "), font.width("Text Color: "),
+            font.width("Behavior: "), font.width("Title: ")
+    );
     EditBox nameField = this.addRenderableWidget(new EditBox(font, minX, 5, 120, 20, TextComponent.EMPTY));
     nameField.setResponder(this::setName);
     nameField.setMaxLength(200);
@@ -178,19 +193,24 @@ public class NpcBuilderScreen extends Screen {
 
     this.nameVisibleCheckbox = this.addRenderableWidget(new Checkbox(minX + 130 + font.width("Visible? "), 5, 20, 20, TextComponent.EMPTY, currentData.isNameVisible));
 
-    EditBox textureField = this.addRenderableWidget(new EditBox(font, minX, 30, 120, 20, TextComponent.EMPTY));
+    EditBox titleField = this.addRenderableWidget(new EditBox(font, minX, 30, 120, 20, TextComponent.EMPTY));
+    titleField.setResponder(this::setTitle);
+    titleField.setMaxLength(200);
+    titleField.setValue(currentData.title);
+
+    EditBox textureField = this.addRenderableWidget(new EditBox(font, minX, 55, 120, 20, TextComponent.EMPTY));
     textureField.setResponder(this::setTexture);
     textureField.setFilter(textFilter);
     textureField.setMaxLength(200);
     textureField.setValue(currentData.texture);
 
-    EditBox dialogueField = this.addRenderableWidget(new EditBox(font, minX, 55, 120, 20, TextComponent.EMPTY));
+    EditBox dialogueField = this.addRenderableWidget(new EditBox(font, minX, 80, 120, 20, TextComponent.EMPTY));
     dialogueField.setResponder(this::setDialogue);
     dialogueField.setFilter(textFilter);
     dialogueField.setMaxLength(200);
     dialogueField.setValue(currentData.dialogue);
 
-    EditBox behaviorField = this.addRenderableWidget(new EditBox(font, minX, 80, 120, 20, TextComponent.EMPTY));
+    EditBox behaviorField = this.addRenderableWidget(new EditBox(font, minX, 105, 120, 20, TextComponent.EMPTY));
     behaviorField.setResponder(this::setBehavior);
     behaviorField.setFilter(textFilter);
     behaviorField.setMaxLength(200);
@@ -201,9 +221,9 @@ public class NpcBuilderScreen extends Screen {
 
     this.isResourceLocationCheckbox = this.addRenderableWidget(new Checkbox(minX + 155 + font.width("Slim? ") + font.width("ResourceLocation? "), 30, 20, 20, TextComponent.EMPTY, currentData.isTextureResourceLocation));
 
-    this.redSlider = this.addRenderableWidget(new ColorSliderWidget(this, minX, 105, 20, 100, ColorSliderWidget.Color.RED));
-    this.greenSlider = this.addRenderableWidget(new ColorSliderWidget(this, minX + 30, 105, 20, 100, ColorSliderWidget.Color.GREEN));
-    this.blueSlider = this.addRenderableWidget(new ColorSliderWidget(this, minX + 60, 105, 20, 100, ColorSliderWidget.Color.BLUE));
+    this.redSlider = this.addRenderableWidget(new ColorSliderWidget(this, minX, 130, 20, 75, ColorSliderWidget.Color.RED));
+    this.greenSlider = this.addRenderableWidget(new ColorSliderWidget(this, minX + 30, 130, 20, 75, ColorSliderWidget.Color.GREEN));
+    this.blueSlider = this.addRenderableWidget(new ColorSliderWidget(this, minX + 60, 130, 20, 75, ColorSliderWidget.Color.BLUE));
 
     this.redField = this.addRenderableWidget(new EditBox(font, minX - 5, 210, 30, 20, TextComponent.EMPTY));
     this.redField.setResponder(this::setRFromString);
@@ -246,7 +266,7 @@ public class NpcBuilderScreen extends Screen {
     // Confirm Button
     this.addRenderableWidget(new Button(width - 60, height - 20, 60, 20, new TextComponent("Confirm"), btn -> {
       PacketDispatcher.sendToServer(
-              new CEditNpc(this.npcEntity.getId(), currentData.isNameVisible, currentData.name, currentData.texture, currentData.isTextureResourceLocation, currentData.isSlim, currentData.dialogue,
+              new CEditNpc(this.npcEntity.getId(), currentData.isNameVisible, currentData.name, currentData.title, currentData.texture, currentData.isTextureResourceLocation, currentData.isSlim, currentData.dialogue,
                       currentData.behavior, currentData.textColor, currentData.items, currentData.pose, currentData.renderer, currentData.rendererTag, currentData.scaleX, currentData.scaleY, currentData.scaleZ));
       isConfirmClose = true;
       minecraft.setScreen(null);
@@ -255,7 +275,7 @@ public class NpcBuilderScreen extends Screen {
     // Inventory Button
     this.addRenderableWidget(new Button(width - 60, height - 40, 60, 20, new TextComponent("Inventory"), btn -> {
       PacketDispatcher.sendToServer(
-              new CEditNpc(this.npcEntity.getId(), currentData.isNameVisible, currentData.name, currentData.texture, currentData.isTextureResourceLocation, currentData.isSlim, currentData.dialogue,
+              new CEditNpc(this.npcEntity.getId(), currentData.isNameVisible, currentData.name, currentData.title, currentData.texture, currentData.isTextureResourceLocation, currentData.isSlim, currentData.dialogue,
                       currentData.behavior, currentData.textColor, currentData.items, currentData.pose, currentData.renderer, currentData.rendererTag, currentData.scaleX, currentData.scaleY, currentData.scaleZ));
       PacketDispatcher.sendToServer(new CRequestContainer(this.npcEntity.getId(), CRequestContainer.ContainerType.NPCINVENTORY));
     }));
@@ -263,7 +283,7 @@ public class NpcBuilderScreen extends Screen {
     // Trades Button
     this.addRenderableWidget(new Button(width - 60, height - 60, 60, 20, new TextComponent("Trades"), btn -> {
       PacketDispatcher.sendToServer(
-              new CEditNpc(this.npcEntity.getId(), currentData.isNameVisible, currentData.name, currentData.texture, currentData.isTextureResourceLocation, currentData.isSlim, currentData.dialogue,
+              new CEditNpc(this.npcEntity.getId(), currentData.isNameVisible, currentData.name, currentData.title, currentData.texture, currentData.isTextureResourceLocation, currentData.isSlim, currentData.dialogue,
                       currentData.behavior, currentData.textColor, currentData.items, currentData.pose, currentData.renderer, currentData.rendererTag, currentData.scaleX, currentData.scaleY, currentData.scaleZ));
       PacketDispatcher.sendToServer(new CRequestContainer(this.npcEntity.getId(), CRequestContainer.ContainerType.TRADE_EDITOR));
     }));
@@ -271,7 +291,7 @@ public class NpcBuilderScreen extends Screen {
     // Reset Behavior Button
     this.addRenderableWidget(new Button(width - 60, height - 80, 60, 20, new TextComponent("Reset AI"), btn -> {
       PacketDispatcher.sendToServer(
-              new CEditNpc(this.npcEntity.getId(), currentData.isNameVisible, currentData.name, currentData.texture, currentData.isTextureResourceLocation, currentData.isSlim, currentData.dialogue,
+              new CEditNpc(this.npcEntity.getId(), currentData.isNameVisible, currentData.name, currentData.title, currentData.texture, currentData.isTextureResourceLocation, currentData.isSlim, currentData.dialogue,
                       currentData.behavior, currentData.textColor, currentData.items, currentData.pose, true, currentData.renderer, currentData.rendererTag, currentData.scaleX, currentData.scaleY, currentData.scaleZ));
     }));
 
@@ -289,6 +309,11 @@ public class NpcBuilderScreen extends Screen {
   private void setName(String s) {
     currentData.name = s;
     npcEntity.setCustomName(new TextComponent(s));
+  }
+
+  private void setTitle(String s) {
+    currentData.title = s;
+    npcEntity.setTitle(s);
   }
 
   private void setTexture(String s) {
@@ -488,18 +513,19 @@ public class NpcBuilderScreen extends Screen {
     int center = (20 - font.lineHeight) / 2;
     drawString(matrixStack, font, "Name: ", 5, 5 + center, 0xFFFFFF);
     drawString(matrixStack, font, "Visible? ", minX + 130, 5 + center, 0xFFFFFF);
-    drawString(matrixStack, font, "Texture: ", 5, 30 + center, 0xFFFFFF);
+    drawString(matrixStack, font, "Title: ", 5, 30 + center, 0xFFFFFF);
+    drawString(matrixStack, font, "Texture: ", 5, 55 + center, 0xFFFFFF);
     drawString(matrixStack, font, "Slim? ", minX + 130, 30 + center, this.slimCheckBox.active ? 0xFFFFFF : 0x7D7D7D);
     drawString(matrixStack, font, "ResourceLocation? ", minX + 155 + font.width("Slim? "), 30 + center, 0xFFFFFF);
     drawString(matrixStack, font, "Scale: ", minX + 130, 55 + center, 0xFFFFFF);
 
-    drawString(matrixStack, font, "Dialogue: ", 5, 55 + center, 0xFFFFFF);
-    drawString(matrixStack, font, "Behavior: ", 5, 80 + center, 0xFFFFFF);
+    drawString(matrixStack, font, "Dialogue: ", 5, 80 + center, 0xFFFFFF);
+    drawString(matrixStack, font, "Behavior: ", 5, 105 + center, 0xFFFFFF);
 
-    drawString(matrixStack, font, "Text Color: ", 5, 105 + (100 - font.lineHeight) / 2, 0xFFFFFF);
+    drawString(matrixStack, font, "Text Color: ", 5, 130 + (100 - font.lineHeight) / 2, 0xFFFFFF);
 
-    fill(matrixStack, minX + 89, 121, minX + 116, 147, 0xFF000000);
-    fill(matrixStack, minX + 90, 122, minX + 115, 146, ColorUtil.hexToHexA(currentData.textColor));
+    fill(matrixStack, minX + 89, 146, minX + 116, 172, 0xFF000000);
+    fill(matrixStack, minX + 90, 147, minX + 115, 171, ColorUtil.hexToHexA(currentData.textColor));
 
     super.render(matrixStack, mouseX, mouseY, partialTicks);
   }

--- a/src/main/java/flash/npcmod/client/gui/screen/quests/QuestEditorScreen.java
+++ b/src/main/java/flash/npcmod/client/gui/screen/quests/QuestEditorScreen.java
@@ -86,9 +86,7 @@ public class QuestEditorScreen extends Screen {
     questEditorScreen.name = quest.getName();
     questEditorScreen.displayName = quest.getDisplayName();
 
-    for (QuestObjective questObjective : quest.getObjectives()) {
-      questEditorScreen.objectives.add(questObjective);
-    }
+    questEditorScreen.objectives.addAll(quest.getObjectives());
 
     questEditorScreen.xpReward = quest.getXpReward();
     questEditorScreen.itemRewards = quest.getItemRewards();

--- a/src/main/java/flash/npcmod/client/gui/screen/quests/QuestObjectiveBuilderScreen.java
+++ b/src/main/java/flash/npcmod/client/gui/screen/quests/QuestObjectiveBuilderScreen.java
@@ -292,7 +292,8 @@ public class QuestObjectiveBuilderScreen extends Screen {
         || typeDropdown.getSelectedOption().equals(QuestObjective.ObjectiveType.DeliverToLocation)
         || typeDropdown.getSelectedOption().equals(QuestObjective.ObjectiveType.UseOnEntity)
         || typeDropdown.getSelectedOption().equals(QuestObjective.ObjectiveType.UseOnBlock)
-        || typeDropdown.getSelectedOption().equals(QuestObjective.ObjectiveType.Use);
+        || typeDropdown.getSelectedOption().equals(QuestObjective.ObjectiveType.Use)
+        || typeDropdown.getSelectedOption().equals(QuestObjective.ObjectiveType.CraftItem);
     itemFromInventoryButton.active = !typeDropdown.isShowingOptions();
 
 
@@ -421,6 +422,9 @@ public class QuestObjectiveBuilderScreen extends Screen {
         break;
       case Scoreboard:
         questObjective = new QuestObjectiveTypes.ScoreboardObjective(id, name, primaryObjective, amount);
+        break;
+      case CraftItem:
+        questObjective = new QuestObjectiveTypes.CraftItemObjective(id, name, itemStackObjective, amount);
         break;
     }
     if (questObjective != null) {

--- a/src/main/java/flash/npcmod/client/gui/screen/quests/QuestObjectiveBuilderScreen.java
+++ b/src/main/java/flash/npcmod/client/gui/screen/quests/QuestObjectiveBuilderScreen.java
@@ -360,7 +360,7 @@ public class QuestObjectiveBuilderScreen extends Screen {
 
   private boolean canCreateObjective() {
     return switch (typeDropdown.getSelectedOption()) {
-      case Gather, Use -> itemStackObjective != null && !itemStackObjective.isEmpty() && amount > 0;
+      case Gather, Use, CraftItem -> itemStackObjective != null && !itemStackObjective.isEmpty() && amount > 0;
       case Kill -> entityObjective != null && amount > 0;
       case DeliverToEntity, UseOnEntity ->
               itemStackObjective != null && !itemStackObjective.isEmpty() && entityObjective != null && amount > 0;

--- a/src/main/java/flash/npcmod/client/gui/screen/quests/QuestObjectiveBuilderScreen.java
+++ b/src/main/java/flash/npcmod/client/gui/screen/quests/QuestObjectiveBuilderScreen.java
@@ -109,9 +109,6 @@ public class QuestObjectiveBuilderScreen extends Screen {
 
       if (questObjective.getObjective() instanceof ItemStack) {
         itemStackObjective = questObjective.getObjective();
-      } else if (questObjective.getObjective() instanceof LivingEntity) {
-        entityObjective = ((LivingEntity) questObjective.getObjective()).getType();
-        entityObjectiveTag = ((LivingEntity) questObjective.getObjective()).saveWithoutId(new CompoundTag());
       } else if (questObjective.getObjective() instanceof BlockState) {
         blockStateObjective = questObjective.getObjective();
       }
@@ -119,16 +116,53 @@ public class QuestObjectiveBuilderScreen extends Screen {
 
       if (questObjective.getSecondaryObjective() instanceof ItemStack) {
         itemStackObjective = questObjective.getSecondaryObjective();
-      } else if (questObjective.getSecondaryObjective() instanceof LivingEntity) {
-        entityObjective = ((LivingEntity) questObjective.getSecondaryObjective()).getType();
-        entityObjectiveTag = ((LivingEntity) questObjective.getSecondaryObjective()).saveWithoutId(new CompoundTag());
       } else if (questObjective.getSecondaryObjective() instanceof BlockState) {
         blockStateObjective = questObjective.getSecondaryObjective();
       }
       secondaryObjective = questObjective.secondaryToString();
 
+      if (isEntityObjective(questObjective)) {
+        // TODO class EntityQuestObjective extends QuestObjective
+        switch (questObjective.getType()) {
+          case Kill -> {
+            QuestObjectiveTypes.KillObjective killObjective = (QuestObjectiveTypes.KillObjective) questObjective;
+            try {
+              entityObjective = EntityType.byString(killObjective.getEntityKey()).get();
+            } catch (Exception e) {
+              entityObjective = EntityType.PIG;
+            }
+            entityObjectiveTag = killObjective.getEntityTag();
+          }
+          case UseOnEntity -> {
+            QuestObjectiveTypes.UseOnEntityObjective useOnEntityObjective = (QuestObjectiveTypes.UseOnEntityObjective) questObjective;
+            try {
+              entityObjective = EntityType.byString(useOnEntityObjective.getEntityKey()).get();
+            } catch (Exception e) {
+              entityObjective = EntityType.PIG;
+            }
+            entityObjectiveTag = useOnEntityObjective.getEntityTag();
+          }
+          case DeliverToEntity -> {
+            QuestObjectiveTypes.DeliverToEntityObjective deliverToEntityObjective = (QuestObjectiveTypes.DeliverToEntityObjective) questObjective;
+            try {
+              entityObjective = EntityType.byString(deliverToEntityObjective.getEntityKey()).get();
+            } catch (Exception e) {
+              entityObjective = EntityType.PIG;
+            }
+            entityObjectiveTag = deliverToEntityObjective.getEntityTag();
+          }
+        }
+      }
+
       objectiveType = questObjective.getType();
     }
+  }
+
+  private boolean isEntityObjective(QuestObjective objective) {
+    return switch (objective.getType()) {
+      case Kill, UseOnEntity, DeliverToEntity -> true;
+      default -> false;
+    };
   }
 
   @Override

--- a/src/main/java/flash/npcmod/client/render/entity/NpcEntityRenderer.java
+++ b/src/main/java/flash/npcmod/client/render/entity/NpcEntityRenderer.java
@@ -2,10 +2,12 @@ package flash.npcmod.client.render.entity;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.math.Matrix4f;
 import flash.npcmod.Main;
 import flash.npcmod.core.client.SkinUtil;
 import flash.npcmod.entity.NpcEntity;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
 import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.model.PlayerModel;
@@ -436,6 +438,37 @@ public class NpcEntityRenderer extends LivingEntityRenderer<NpcEntity, PlayerMod
   @Override
   protected void renderNameTag(NpcEntity entityIn, Component displayNameIn, PoseStack matrixStackIn,
                             MultiBufferSource bufferIn, int packedLightIn) {
-    if (entityIn.isCustomNameVisible()) super.renderNameTag(entityIn, displayNameIn, matrixStackIn, bufferIn, packedLightIn);
+    if (entityIn.isCustomNameVisible()) {
+      double d0 = this.entityRenderDispatcher.distanceToSqr(entityIn);
+      if (net.minecraftforge.client.ForgeHooksClient.isNameplateInRenderDistance(entityIn, d0)) {
+        boolean flag = !entityIn.isDiscrete();
+        boolean isTitleVisible = entityIn.isTitleVisible();
+        float f = entityIn.getBbHeight() + 0.5F;
+        int i = isTitleVisible ? -10 : 0;
+        matrixStackIn.pushPose();
+        matrixStackIn.translate(0.0D, (double)f, 0.0D);
+        matrixStackIn.mulPose(this.entityRenderDispatcher.cameraOrientation());
+        matrixStackIn.scale(-0.025F, -0.025F, 0.025F);
+        Matrix4f matrix4f = matrixStackIn.last().pose();
+        float f1 = Minecraft.getInstance().options.getBackgroundOpacity(0.25F);
+        int j = (int)(f1 * 255.0F) << 24;
+        Font font = this.getFont();
+        float f2 = (float)(-font.width(displayNameIn) / 2);
+        font.drawInBatch(displayNameIn, f2, (float)i, 553648127, false, matrix4f, bufferIn, flag, j, packedLightIn);
+        if (flag) {
+          font.drawInBatch(displayNameIn, f2, (float)i, -1, false, matrix4f, bufferIn, false, 0, packedLightIn);
+        }
+        if (isTitleVisible) {
+          Component title = entityIn.getTitleComponent();
+          float f3 = (float)(-font.width(title) / 2);
+          font.drawInBatch(title, f3, 0f, 553648127, false, matrix4f, bufferIn, flag, j, packedLightIn);
+          if (flag) {
+            font.drawInBatch(title, f3, 0f, -1, false, matrix4f, bufferIn, false, 0, packedLightIn);
+          }
+        }
+
+        matrixStackIn.popPose();
+      }
+    }
   }
 }

--- a/src/main/java/flash/npcmod/commands/QuestsCommand.java
+++ b/src/main/java/flash/npcmod/commands/QuestsCommand.java
@@ -61,8 +61,10 @@ public class QuestsCommand extends Command {
 
     builder.then(literal("reset")
         .then(argument("player", EntityArgument.player())
-        .then(argument("quest", StringArgumentType.string())
-            .executes(context -> reset(context.getSource(), EntityArgument.getPlayer(context, "player"), StringArgumentType.getString(context, "quest"))))));
+        .then(literal("quest").then(argument("quest", StringArgumentType.string())
+                .executes(context -> reset(context.getSource(), EntityArgument.getPlayer(context, "player"), StringArgumentType.getString(context, "quest")))))
+        .then(literal("all")
+                .executes(context -> resetAll(context.getSource(), EntityArgument.getPlayer(context, "player"))))));
   }
 
   @Override
@@ -192,6 +194,15 @@ public class QuestsCommand extends Command {
       }
       else
         source.sendSuccess(new TextComponent(quest + " does not exist").withStyle(ChatFormatting.RED), true);
+    }
+    return 0;
+  }
+
+  private int resetAll(CommandSourceStack source, Player player) {
+    if (player != null && player.isAlive()) {
+      IQuestCapability capability = QuestCapabilityProvider.getCapability(player);
+      capability.resetAllQuestProgress();
+      source.sendSuccess(new TextComponent("Reset " + player.getName().getString() + "'s quest data").withStyle(ChatFormatting.GREEN), true);
     }
     return 0;
   }

--- a/src/main/java/flash/npcmod/core/functions/defaultfunctions/AcceptQuestFunction.java
+++ b/src/main/java/flash/npcmod/core/functions/defaultfunctions/AcceptQuestFunction.java
@@ -11,22 +11,38 @@ import flash.npcmod.network.PacketDispatcher;
 import flash.npcmod.network.packets.server.SAcceptQuest;
 import net.minecraft.server.level.ServerPlayer;
 
+import java.util.Locale;
+import java.util.UUID;
+
 public class AcceptQuestFunction extends AbstractFunction {
 
   public AcceptQuestFunction() {
-    super("acceptQuest", new String[]{"questName"}, empty);
+    super("acceptQuest", new String[]{"questName","[turnInType]","[turnInUuid]"}, empty);
   }
 
   @Override
   public void call(String[] params, ServerPlayer sender, NpcEntity npcEntity) {
-    if (params.length == 1) {
+    if (params.length >= 1 && params.length <= 3) {
       Quest quest = CommonQuestUtil.fromName(params[0]);
       if (quest != null) {
         IQuestCapability capability = QuestCapabilityProvider.getCapability(sender);
-        QuestInstance questInstance = new QuestInstance(quest, npcEntity.getUUID(), npcEntity.getName().getString(), sender);
+        UUID uuid = npcEntity.getUUID();
+        QuestInstance.TurnInType turnInType = QuestInstance.TurnInType.QuestGiver;
+        if (params.length == 2 && params[1].equalsIgnoreCase("auto")) {
+          turnInType = QuestInstance.TurnInType.AutoTurnIn;
+        }
+        else if (params.length == 3 && params[1].equalsIgnoreCase("npc")) {
+          try {
+            uuid = UUID.fromString(params[2]);
+            turnInType = QuestInstance.TurnInType.NpcByUuid;
+          } catch (Exception e) {
+            uuid = npcEntity.getUUID();
+          }
+        }
+        QuestInstance questInstance = new QuestInstance(quest, uuid, npcEntity.getName().getString(), turnInType, sender);
         if (!capability.getAcceptedQuests().contains(questInstance)) {
           capability.acceptQuest(questInstance);
-          PacketDispatcher.sendTo(new SAcceptQuest(params[0], npcEntity.getId()), sender);
+          PacketDispatcher.sendTo(new SAcceptQuest(params[0], npcEntity.getId(), turnInType, uuid), sender);
         }
       }
       debugUsage(sender, npcEntity);

--- a/src/main/java/flash/npcmod/core/quests/Quest.java
+++ b/src/main/java/flash/npcmod/core/quests/Quest.java
@@ -18,13 +18,13 @@ import static flash.npcmod.core.ItemUtil.*;
 
 public class Quest {
 
-  private String name;
-  private String displayName;
-  private List<QuestObjective> objectives;
-  private int xpReward;
+  private final String name;
+  private final String displayName;
+  private final List<QuestObjective> objectives;
+  private final int xpReward;
   private List<ItemStack> itemRewards;
-  private boolean repeatable;
-  private List<String> runOnComplete;
+  private final boolean repeatable;
+  private final List<String> runOnComplete;
 
   public Quest(String name, String displayName, List<QuestObjective> objectives) {
     this(name, displayName, objectives, 0);
@@ -78,10 +78,6 @@ public class Quest {
     return repeatable;
   }
 
-  public void setRepeatable(boolean b) {
-    this.repeatable = repeatable;
-  }
-
   public List<String> getRunOnComplete() {
     return runOnComplete;
   }
@@ -93,7 +89,7 @@ public class Quest {
     return true;
   }
 
-  public void complete(Player player, UUID pickedUpFrom, String pickedUpFromName) {
+  public void complete(Player player, UUID pickedUpFrom, String pickedUpFromName, QuestInstance.TurnInType turnInType) {
     if (!canComplete()) return;
 
     for (QuestObjective objective : objectives) {
@@ -121,7 +117,7 @@ public class Quest {
       } else if (command.startsWith("acceptQuest:")) {
         Quest quest = CommonQuestUtil.fromName(command.substring(12));
         if (quest != null)
-          QuestCapabilityProvider.getCapability(player).acceptQuest(new QuestInstance(quest, pickedUpFrom, pickedUpFromName, player));
+          QuestCapabilityProvider.getCapability(player).acceptQuest(new QuestInstance(quest, pickedUpFrom, pickedUpFromName, turnInType, player));
       }
     }
   }

--- a/src/main/java/flash/npcmod/core/quests/QuestInstance.java
+++ b/src/main/java/flash/npcmod/core/quests/QuestInstance.java
@@ -20,7 +20,14 @@ public class QuestInstance {
   }
 
   public QuestInstance(Quest quest, UUID pickedUpFrom, String pickedUpFromName, TurnInType turnInType, @Nullable Player player) {
-    this.quest = quest.copy();
+    this(quest, pickedUpFrom, pickedUpFromName, turnInType, player, true);
+  }
+
+  public QuestInstance(Quest quest, UUID pickedUpFrom, String pickedUpFromName, TurnInType turnInType, @Nullable Player player, boolean copy) {
+    if (copy)
+      this.quest = quest.copy();
+    else
+      this.quest = quest;
     this.pickedUpFrom = pickedUpFrom;
     this.pickedUpFromName = pickedUpFromName;
     this.turnInType = turnInType;

--- a/src/main/java/flash/npcmod/core/quests/QuestInstance.java
+++ b/src/main/java/flash/npcmod/core/quests/QuestInstance.java
@@ -7,20 +7,23 @@ import java.util.UUID;
 
 public class QuestInstance {
 
-  private Quest quest;
-  private UUID pickedUpFrom;
-  private String pickedUpFromName;
+  private final Quest quest;
+  private final UUID pickedUpFrom;
+  private final String pickedUpFromName;
+  private final TurnInType turnInType;
   @Nullable
   private Player player;
 
-  public QuestInstance(Quest quest, UUID pickedUpFrom, String pickedUpFromName) {
-    this(quest, pickedUpFrom, pickedUpFromName, null);
+
+  public QuestInstance(Quest quest, UUID pickedUpFrom, String pickedUpFromName, TurnInType turnInType) {
+    this(quest, pickedUpFrom, pickedUpFromName, turnInType, null);
   }
 
-  public QuestInstance(Quest quest, UUID pickedUpFrom, String pickedUpFromName, @Nullable Player player) {
+  public QuestInstance(Quest quest, UUID pickedUpFrom, String pickedUpFromName, TurnInType turnInType, @Nullable Player player) {
     this.quest = quest.copy();
     this.pickedUpFrom = pickedUpFrom;
     this.pickedUpFromName = pickedUpFromName;
+    this.turnInType = turnInType;
     this.player = player;
   }
 
@@ -44,6 +47,10 @@ public class QuestInstance {
     return pickedUpFromName;
   }
 
+  public TurnInType getTurnInType() {
+    return turnInType;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -52,6 +59,12 @@ public class QuestInstance {
     if ((player != null && that.player == null) || (player == null && that.player != null)) return false;
     boolean playerNamesMatch = true;
     if (player != null && that.player != null) playerNamesMatch = player.getName().getString().equals(that.player.getName().getString());
-    return playerNamesMatch && quest.getName().equals(that.quest.getName()) && pickedUpFrom.equals(that.pickedUpFrom);
+    return playerNamesMatch && quest.getName().equals(that.quest.getName()) && pickedUpFrom.equals(that.pickedUpFrom) && turnInType.equals(that.turnInType);
+  }
+
+  public enum TurnInType {
+    QuestGiver,
+    NpcByUuid,
+    AutoTurnIn
   }
 }

--- a/src/main/java/flash/npcmod/core/quests/QuestObjective.java
+++ b/src/main/java/flash/npcmod/core/quests/QuestObjective.java
@@ -81,6 +81,10 @@ public abstract class QuestObjective {
     this.progress = Mth.clamp(progress, 0, amount);
   }
 
+  public void progress(int amount) {
+    this.progress = Mth.clamp(this.progress + amount, 0, this.amount);
+  }
+
   public boolean isComplete() {
     if (forceComplete && !completed) progress = amount;
     this.completed = progress == amount;
@@ -244,7 +248,8 @@ public abstract class QuestObjective {
     UseOnEntity,
     UseOnBlock,
     Use,
-    Scoreboard;
+    Scoreboard,
+    CraftItem;
 
     ObjectiveType() {}
 
@@ -290,43 +295,30 @@ public abstract class QuestObjective {
     String secondaryObjective = "";
     if (jsonObject.has("secondaryObjective"))
       secondaryObjective = jsonObject.get("secondaryObjective").getAsString();
-    QuestObjective questObjective;
-    switch (objectiveType) {
-      default:
-        questObjective = new QuestObjectiveTypes.GatherObjective(id, objectiveName, stackFromString(primaryObjective), objectiveAmount);
-        break;
-      case Kill:
-        questObjective = new QuestObjectiveTypes.KillObjective(id, objectiveName, primaryObjective, objectiveAmount);
-        break;
-      case DeliverToEntity:
-        questObjective = new QuestObjectiveTypes.DeliverToEntityObjective(id, objectiveName, stackFromString(primaryObjective), secondaryObjective, objectiveAmount);
-        break;
-      case DeliverToLocation:
-        questObjective = new QuestObjectiveTypes.DeliverToLocationObjective(id, objectiveName, stackFromString(primaryObjective), QuestObjectiveTypes.areaFromString(secondaryObjective), objectiveAmount);
-        break;
-      case Escort:
+    QuestObjective questObjective = switch (objectiveType) {
+      default ->
+              new QuestObjectiveTypes.GatherObjective(id, objectiveName, stackFromString(primaryObjective), objectiveAmount);
+      case Kill -> new QuestObjectiveTypes.KillObjective(id, objectiveName, primaryObjective, objectiveAmount);
+      case DeliverToEntity ->
+              new QuestObjectiveTypes.DeliverToEntityObjective(id, objectiveName, stackFromString(primaryObjective), secondaryObjective, objectiveAmount);
+      case DeliverToLocation ->
+              new QuestObjectiveTypes.DeliverToLocationObjective(id, objectiveName, stackFromString(primaryObjective), QuestObjectiveTypes.areaFromString(secondaryObjective), objectiveAmount);
+      case Escort ->
         // TODO figure out how this should work
-        questObjective = new QuestObjectiveTypes.EscortObjective(id, objectiveName, primaryObjective, Path.fromString(secondaryObjective));
-        break;
-      case Talk:
-        questObjective = new QuestObjectiveTypes.TalkObjective(id, objectiveName, primaryObjective, secondaryObjective);
-        break;
-      case Find:
-        questObjective = new QuestObjectiveTypes.FindObjective(id, objectiveName, QuestObjectiveTypes.areaFromString(primaryObjective));
-        break;
-      case UseOnEntity:
-        questObjective = new QuestObjectiveTypes.UseOnEntityObjective(id, objectiveName, stackFromString(primaryObjective), secondaryObjective, objectiveAmount);
-        break;
-      case UseOnBlock:
-        questObjective = new QuestObjectiveTypes.UseOnBlockObjective(id, objectiveName, stackFromString(primaryObjective), QuestObjectiveTypes.blockStateFromString(secondaryObjective), objectiveAmount);
-        break;
-      case Use:
-        questObjective = new QuestObjectiveTypes.UseObjective(id, objectiveName, stackFromString(primaryObjective), objectiveAmount);
-        break;
-      case Scoreboard:
-        questObjective = new QuestObjectiveTypes.ScoreboardObjective(id, objectiveName, primaryObjective, objectiveAmount);
-        break;
-    }
+              new QuestObjectiveTypes.EscortObjective(id, objectiveName, primaryObjective, Path.fromString(secondaryObjective));
+      case Talk -> new QuestObjectiveTypes.TalkObjective(id, objectiveName, primaryObjective, secondaryObjective);
+      case Find ->
+              new QuestObjectiveTypes.FindObjective(id, objectiveName, QuestObjectiveTypes.areaFromString(primaryObjective));
+      case UseOnEntity ->
+              new QuestObjectiveTypes.UseOnEntityObjective(id, objectiveName, stackFromString(primaryObjective), secondaryObjective, objectiveAmount);
+      case UseOnBlock ->
+              new QuestObjectiveTypes.UseOnBlockObjective(id, objectiveName, stackFromString(primaryObjective), QuestObjectiveTypes.blockStateFromString(secondaryObjective), objectiveAmount);
+      case Use ->
+              new QuestObjectiveTypes.UseObjective(id, objectiveName, stackFromString(primaryObjective), objectiveAmount);
+      case Scoreboard ->
+              new QuestObjectiveTypes.ScoreboardObjective(id, objectiveName, primaryObjective, objectiveAmount);
+      case CraftItem -> new QuestObjectiveTypes.CraftItemObjective(id, objectiveName, stackFromString(primaryObjective), objectiveAmount);
+    };
 
     if (jsonObject.has("isHidden"))
       questObjective.setHidden(jsonObject.get("isHidden").getAsBoolean());

--- a/src/main/java/flash/npcmod/core/quests/QuestObjective.java
+++ b/src/main/java/flash/npcmod/core/quests/QuestObjective.java
@@ -296,7 +296,7 @@ public abstract class QuestObjective {
     if (jsonObject.has("secondaryObjective"))
       secondaryObjective = jsonObject.get("secondaryObjective").getAsString();
     QuestObjective questObjective = switch (objectiveType) {
-      default ->
+      case Gather ->
               new QuestObjectiveTypes.GatherObjective(id, objectiveName, stackFromString(primaryObjective), objectiveAmount);
       case Kill -> new QuestObjectiveTypes.KillObjective(id, objectiveName, primaryObjective, objectiveAmount);
       case DeliverToEntity ->

--- a/src/main/java/flash/npcmod/core/quests/QuestObjective.java
+++ b/src/main/java/flash/npcmod/core/quests/QuestObjective.java
@@ -2,9 +2,14 @@ package flash.npcmod.core.quests;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.mojang.brigadier.StringReader;
+import com.mojang.datafixers.util.Pair;
+import flash.npcmod.Main;
 import flash.npcmod.config.ConfigHolder;
 import flash.npcmod.core.pathing.Path;
 import net.minecraft.ChatFormatting;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.TagParser;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.Mth;
@@ -288,6 +293,7 @@ public abstract class QuestObjective {
   }
 
   public static QuestObjective fromJson(JsonObject jsonObject) {
+    Main.LOGGER.debug("Loading quest from json");
     int id = jsonObject.get("index").getAsInt();
     String objectiveName = jsonObject.get("name").getAsString();
     int type = Mth.clamp(jsonObject.get("type").getAsInt(), 0, QuestObjective.ObjectiveType.values().length);
@@ -299,8 +305,9 @@ public abstract class QuestObjective {
       secondaryObjective = jsonObject.get("secondaryObjective").getAsString();
     QuestObjective questObjective = switch (objectiveType) {
       case Gather ->
-              new QuestObjectiveTypes.GatherObjective(id, objectiveName, stackFromString(primaryObjective), objectiveAmount);
-      case Kill -> new QuestObjectiveTypes.KillObjective(id, objectiveName, primaryObjective, objectiveAmount);
+        new QuestObjectiveTypes.GatherObjective(id, objectiveName, stackFromString(primaryObjective), objectiveAmount);
+      case Kill ->
+              new QuestObjectiveTypes.KillObjective(id, objectiveName, primaryObjective, objectiveAmount);
       case DeliverToEntity ->
               new QuestObjectiveTypes.DeliverToEntityObjective(id, objectiveName, stackFromString(primaryObjective), secondaryObjective, objectiveAmount);
       case DeliverToLocation ->

--- a/src/main/java/flash/npcmod/core/quests/QuestObjective.java
+++ b/src/main/java/flash/npcmod/core/quests/QuestObjective.java
@@ -225,6 +225,8 @@ public abstract class QuestObjective {
       questObjective = new QuestObjectiveTypes.UseOnBlockObjective(id, name, itemStack, getSecondaryObjective(), amount);
     else if (type.equals(ObjectiveType.Use))
       questObjective = new QuestObjectiveTypes.UseObjective(id, name, itemStack, amount);
+    else if (type.equals(ObjectiveType.CraftItem))
+      questObjective = new QuestObjectiveTypes.CraftItemObjective(id, name, itemStack, amount);
 
     if (questObjective != this) {
       questObjective.setQuest(this.getQuest());

--- a/src/main/java/flash/npcmod/core/quests/QuestObjectiveTypes.java
+++ b/src/main/java/flash/npcmod/core/quests/QuestObjectiveTypes.java
@@ -2,10 +2,13 @@ package flash.npcmod.core.quests;
 
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.datafixers.util.Pair;
 import flash.npcmod.Main;
 import flash.npcmod.core.pathing.Path;
 import net.minecraft.commands.arguments.blocks.BlockStateArgument;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.TagParser;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
@@ -46,11 +49,17 @@ public class QuestObjectiveTypes {
   }
 
   public static class KillObjective extends QuestObjective {
+    private final String entityObjective;
     private final String livingEntityKey;
+    private final CompoundTag livingEntityTag;
 
-    public KillObjective(int id, String name, String livingEntityKey, int amount) {
+    public KillObjective(int id, String name, String entityObjective, int amount) {
       super(id, name, ObjectiveType.Kill, amount);
-      this.livingEntityKey = livingEntityKey;
+      this.entityObjective = entityObjective;
+      Main.LOGGER.debug("Creating kill objective with " + entityObjective);
+      Pair<String, CompoundTag> keyAndTagPair = getEntityObjectiveFromString(entityObjective);
+      this.livingEntityKey = keyAndTagPair.getFirst();
+      this.livingEntityTag = keyAndTagPair.getSecond();
     }
 
     @Override
@@ -58,14 +67,23 @@ public class QuestObjectiveTypes {
       return livingEntityKey;
     }
 
+    public String getEntityKey() {
+      return livingEntityKey;
+    }
+
+    public CompoundTag getEntityTag() {
+      return livingEntityTag;
+    }
+
     @Override
     public String primaryToString() {
-      return livingEntityKey;
+      return entityObjective;
     }
 
     @Override
     public KillObjective copy() {
-      KillObjective copy = new KillObjective(getId(), getName(), livingEntityKey, getAmount());
+      Main.LOGGER.debug("Creating killObjective copy");
+      KillObjective copy = new KillObjective(getId(), getName(), entityObjective, getAmount());
       copyTo(copy);
       return copy;
     }
@@ -73,12 +91,17 @@ public class QuestObjectiveTypes {
 
   public static class DeliverToEntityObjective extends QuestObjective {
     private final ItemStack itemStack;
+    private final String entityObjective;
     private final String livingEntityKey;
+    private final CompoundTag livingEntityTag;
 
-    public DeliverToEntityObjective(int id, String name, ItemStack itemStack, String livingEntityKey, int amount) {
+    public DeliverToEntityObjective(int id, String name, ItemStack itemStack, String entityObjective, int amount) {
       super(id, name, ObjectiveType.DeliverToEntity, amount);
       this.itemStack = itemStack;
-      this.livingEntityKey = livingEntityKey;
+      this.entityObjective = entityObjective;
+      Pair<String, CompoundTag> keyAndTagPair = getEntityObjectiveFromString(entityObjective);
+      this.livingEntityKey = keyAndTagPair.getFirst();
+      this.livingEntityTag = keyAndTagPair.getSecond();
     }
 
     @Override
@@ -88,7 +111,7 @@ public class QuestObjectiveTypes {
 
     @Override
     public String getSecondaryObjective() {
-      return livingEntityKey;
+      return entityObjective;
     }
 
     @Override
@@ -98,12 +121,20 @@ public class QuestObjectiveTypes {
 
     @Override
     public String secondaryToString() {
+      return entityObjective;
+    }
+
+    public String getEntityKey() {
       return livingEntityKey;
+    }
+
+    public CompoundTag getEntityTag() {
+      return livingEntityTag;
     }
 
     @Override
     public DeliverToEntityObjective copy() {
-      DeliverToEntityObjective copy = new DeliverToEntityObjective(getId(), getName(), itemStack, livingEntityKey, getAmount());
+      DeliverToEntityObjective copy = new DeliverToEntityObjective(getId(), getName(), itemStack, entityObjective, getAmount());
       copyTo(copy);
       return copy;
     }
@@ -256,12 +287,17 @@ public class QuestObjectiveTypes {
 
   public static class UseOnEntityObjective extends QuestObjective {
     private final ItemStack itemStack;
+    private final String entityObjective;
     private final String livingEntityKey;
+    private final CompoundTag livingEntityTag;
 
-    public UseOnEntityObjective(int id, String name, ItemStack itemStack, String livingEntityKey, int amount) {
+    public UseOnEntityObjective(int id, String name, ItemStack itemStack, String entityObjective, int amount) {
       super(id, name, ObjectiveType.UseOnEntity, amount);
       this.itemStack = itemStack;
-      this.livingEntityKey = livingEntityKey;
+      this.entityObjective = entityObjective;
+      Pair<String, CompoundTag> keyAndTagPair = getEntityObjectiveFromString(entityObjective);
+      this.livingEntityKey = keyAndTagPair.getFirst();
+      this.livingEntityTag = keyAndTagPair.getSecond();
     }
 
     @Override
@@ -271,7 +307,15 @@ public class QuestObjectiveTypes {
 
     @Override
     public String getSecondaryObjective() {
+      return entityObjective;
+    }
+
+    public String getEntityKey() {
       return livingEntityKey;
+    }
+
+    public CompoundTag getEntityTag() {
+      return livingEntityTag;
     }
 
     @Override
@@ -281,12 +325,12 @@ public class QuestObjectiveTypes {
 
     @Override
     public String secondaryToString() {
-      return livingEntityKey;
+      return entityObjective;
     }
 
     @Override
     public UseOnEntityObjective copy() {
-      UseOnEntityObjective copy = new UseOnEntityObjective(getId(), getName(), itemStack, livingEntityKey, getAmount());
+      UseOnEntityObjective copy = new UseOnEntityObjective(getId(), getName(), itemStack, entityObjective, getAmount());
       copyTo(copy);
       return copy;
     }
@@ -450,6 +494,21 @@ public class QuestObjectiveTypes {
     } catch (CommandSyntaxException e) {
       return Blocks.AIR.defaultBlockState();
     }
+  }
+
+  private static Pair<String, CompoundTag> getEntityObjectiveFromString(String s) {
+    if (s.contains("::")) {
+      String[] obj = s.split("::");
+      CompoundTag tag = new CompoundTag();
+      try {
+        tag = new TagParser(new StringReader(obj[1])).readStruct();
+        if (tag.contains("id"))
+          tag.remove("id");
+      } catch (Exception ignored) {}
+      return new Pair<>(obj[0], tag);
+    }
+
+    return new Pair<>(s, new CompoundTag());
   }
 
 }

--- a/src/main/java/flash/npcmod/core/quests/QuestObjectiveTypes.java
+++ b/src/main/java/flash/npcmod/core/quests/QuestObjectiveTypes.java
@@ -383,6 +383,32 @@ public class QuestObjectiveTypes {
     }
   }
 
+  public static class CraftItemObjective extends QuestObjective {
+    private final ItemStack itemStack;
+
+    public CraftItemObjective(int id, String name, ItemStack itemStack, int amount) {
+      super(id, name, ObjectiveType.CraftItem, amount);
+      this.itemStack = itemStack;
+    }
+
+    @Override
+    public ItemStack getObjective() {
+      return itemStack;
+    }
+
+    @Override
+    public String primaryToString() {
+      return stackToString(itemStack);
+    }
+
+    @Override
+    public CraftItemObjective copy() {
+      CraftItemObjective copy = new CraftItemObjective(getId(), getName(), itemStack, getAmount());
+      copyTo(copy);
+      return copy;
+    }
+  }
+
   public static String entityToString(LivingEntity livingEntity) {
     return livingEntity.getEncodeId();
   }

--- a/src/main/java/flash/npcmod/entity/NpcEntity.java
+++ b/src/main/java/flash/npcmod/entity/NpcEntity.java
@@ -506,7 +506,13 @@ public class NpcEntity extends PathfinderMob {
     @Override
     protected float getStandingEyeHeight(@NotNull Pose poseIn, @NotNull EntityDimensions sizeIn) {
         if (entityToRenderAs == null) {
-            return getDimensions(poseIn).height * 0.85F;
+            // Player#getStandingEyeHeight
+            return switch (poseIn) {
+                case SWIMMING, FALL_FLYING -> 0.4f;
+                case SPIN_ATTACK -> 1.1F;
+                case CROUCHING -> 1.27F;
+                default -> 1.62F;
+            };
         }
         return entityToRenderAs.getEyeHeightAccess(poseIn, sizeIn);
     }

--- a/src/main/java/flash/npcmod/entity/NpcEntity.java
+++ b/src/main/java/flash/npcmod/entity/NpcEntity.java
@@ -11,6 +11,7 @@ import flash.npcmod.core.behaviors.Trigger;
 import flash.npcmod.core.ItemUtil;
 import flash.npcmod.core.behaviors.BehaviorSavedData;
 import flash.npcmod.core.client.behaviors.ClientBehaviorUtil;
+import flash.npcmod.core.quests.Quest;
 import flash.npcmod.core.quests.QuestInstance;
 import flash.npcmod.core.trades.TradeOffer;
 import flash.npcmod.core.trades.TradeOffers;
@@ -505,7 +506,10 @@ public class NpcEntity extends PathfinderMob {
                 List<QuestInstance> markedForCompletion = new ArrayList<>();
 
                 for (QuestInstance questInstance : questCapability.getAcceptedQuests()) {
-                    if (questInstance.getPickedUpFrom().equals(this.getUUID()) && questInstance.getQuest().canComplete()) {
+                    if ((questInstance.getTurnInType() == QuestInstance.TurnInType.QuestGiver ||
+                            questInstance.getTurnInType() == QuestInstance.TurnInType.NpcByUuid) &&
+                            questInstance.getPickedUpFrom().equals(this.getUUID()) &&
+                            questInstance.getQuest().canComplete()) {
                         markedForCompletion.add(questInstance);
                     }
                 }

--- a/src/main/java/flash/npcmod/events/ClientEvents.java
+++ b/src/main/java/flash/npcmod/events/ClientEvents.java
@@ -306,9 +306,7 @@ public class ClientEvents {
   @SubscribeEvent
   public void renderQuestIconAboveNpc(RenderNameplateEvent event) {
     if (minecraft.player == null || !minecraft.player.isAlive()) return;
-    if (!(event.getEntity() instanceof NpcEntity)) return;
-
-    NpcEntity npcEntity = (NpcEntity) event.getEntity();
+    if (!(event.getEntity() instanceof NpcEntity npcEntity)) return;
 
     IQuestCapability capability = QuestCapabilityProvider.getCapability(minecraft.player);
 
@@ -339,7 +337,7 @@ public class ClientEvents {
 
     float size = 12f;
     float xOffset = -size/2;
-    float yOffset = -4f - size - Mth.sin(((float) npcEntity.tickCount + partialTicks) / 10.0F);
+    float yOffset = -4f - size - Mth.sin(((float) npcEntity.tickCount + partialTicks) / 10.0F) - (npcEntity.isTitleVisible() ? 10 : 0);
 
     VertexConsumer builder = bufferIn.getBuffer(RenderType.text(icon));
     int alpha = 32;

--- a/src/main/java/flash/npcmod/events/QuestEvents.java
+++ b/src/main/java/flash/npcmod/events/QuestEvents.java
@@ -106,7 +106,7 @@ public class QuestEvents {
                   BlockPos[] deliveryArea = objective.getSecondaryObjective();
                   if (isPlayerInArea(player, deliveryArea) && hasItem(player, toDeliver)) {
                     int prevProgress = objective.getProgress();
-                    objective.setProgress(objective.getProgress() + getAmount(player, toDeliver));
+                    objective.progress(getAmount(player, toDeliver));
                     takeStack(player, toDeliver, objective.getAmount() - prevProgress);
                   }
                 }
@@ -138,7 +138,7 @@ public class QuestEvents {
           if (!objective.isHidden()) {
             if (objective.getType().equals(QuestObjective.ObjectiveType.Kill)) {
               if (EntityType.getKey(event.getEntityLiving().getType()).toString().equals(objective.getObjective()))
-                objective.setProgress(objective.getProgress() + 1);
+                objective.progress(1);
             }
           }
         }
@@ -163,18 +163,18 @@ public class QuestEvents {
                   if (matches(objective.getObjective(), event.getItemStack())
                       && EntityType.getKey(event.getTarget().getType()).toString().equals(objective.getSecondaryObjective())) {
                     int prevProgress = objective.getProgress();
-                    objective.setProgress(objective.getProgress() + getAmount(player, objective.getObjective()));
+                    objective.progress(getAmount(player, objective.getObjective()));
                     takeStack(player, objective.getObjective(), objective.getAmount() - prevProgress);
                   }
                   break;
                 case UseOnEntity:
                   if (matches(objective.getObjective(), event.getItemStack())
                       && EntityType.getKey(event.getTarget().getType()).toString().equals(objective.getSecondaryObjective()))
-                    objective.setProgress(objective.getProgress() + 1);
+                    objective.progress(1);
                   break;
                 case Use:
                   if (event.getItemStack().getUseDuration() == 0 && matches(objective.getObjective(), event.getItemStack())) {
-                    objective.setProgress(objective.getProgress() + 1);
+                    objective.progress(1);
                   }
               }
             }
@@ -196,10 +196,10 @@ public class QuestEvents {
           if (!objective.isHidden()) {
             if (objective.getType().equals(QuestObjective.ObjectiveType.UseOnBlock)) {
               if (matches(objective.getObjective(), event.getItemStack()) && event.getWorld().getBlockState(event.getHitVec().getBlockPos()).equals(objective.getSecondaryObjective()))
-                objective.setProgress(objective.getProgress() + 1);
+                objective.progress(1);
             } else if (objective.getType().equals(QuestObjective.ObjectiveType.Use)) {
               if (event.getItemStack().getUseDuration() == 0 && matches(objective.getObjective(), event.getItemStack()))
-                objective.setProgress(objective.getProgress() + 1);
+                objective.progress(1);
             }
           }
         }
@@ -223,7 +223,7 @@ public class QuestEvents {
               if (!objective.isHidden()) {
                 if (objective.getType().equals(QuestObjective.ObjectiveType.Use)) {
                   if (matches(objective.getObjective(), itemStack))
-                    objective.setProgress(objective.getProgress() + 1);
+                    objective.progress(1);
                 }
               }
             }
@@ -248,8 +248,30 @@ public class QuestEvents {
               if (!objective.isHidden()) {
                 if (objective.getType().equals(QuestObjective.ObjectiveType.Use)) {
                   if (matches(objective.getObjective(), itemStack))
-                    objective.setProgress(objective.getProgress() + 1);
+                    objective.progress(1);
                 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @SubscribeEvent
+  public void itemCrafted(PlayerEvent.ItemCraftedEvent event) {
+    Player player = event.getPlayer();
+    if (player.isAlive() && !player.level.isClientSide) {
+      ItemStack itemStack = event.getCrafting();
+      IQuestCapability capability = QuestCapabilityProvider.getCapability(player);
+      ArrayList<QuestInstance> acceptedQuests = capability.getAcceptedQuests();
+      for (QuestInstance questInstance : acceptedQuests) {
+        List<QuestObjective> objectives = questInstance.getQuest().getObjectives();
+        for (QuestObjective objective : objectives) {
+          if (!objective.isHidden()) {
+            if (objective.getType().equals(QuestObjective.ObjectiveType.CraftItem)) {
+              if (matches(objective.getObjective(), itemStack)) {
+                objective.progress(itemStack.getCount());
               }
             }
           }

--- a/src/main/java/flash/npcmod/network/packets/client/CEditNpc.java
+++ b/src/main/java/flash/npcmod/network/packets/client/CEditNpc.java
@@ -18,7 +18,7 @@ import java.util.function.Supplier;
 public class CEditNpc {
 
   int entityid;
-  String name, texture, dialogue, behavior;
+  String name, title, texture, dialogue, behavior;
   boolean isSlim, isNameVisible, resetAI, isTextureResourceLocation;
   int textColor;
   ItemStack[] items;
@@ -27,33 +27,34 @@ public class CEditNpc {
   CompoundTag rendererTag;
   float scaleX, scaleY, scaleZ;
 
-  public CEditNpc(int entityid, boolean isNameVisible, String name, String texture, boolean isTextureResourceLocation, boolean isSlim,
+  public CEditNpc(int entityid, boolean isNameVisible, String name, String title, String texture, boolean isTextureResourceLocation, boolean isSlim,
                   String dialogue, String behavior, int textColor, ItemStack[] items, NPCPose pose, String renderer,
                   CompoundTag rendererTag, float scaleX, float scaleY, float scaleZ) {
-    this(entityid, isNameVisible, name, texture, isTextureResourceLocation, isSlim, dialogue, behavior, textColor, items, pose, false, renderer,
+    this(entityid, isNameVisible, name, title, texture, isTextureResourceLocation, isSlim, dialogue, behavior, textColor, items, pose, false, renderer,
             rendererTag, scaleX, scaleY, scaleZ);
   }
 
-  public CEditNpc(int entityid, boolean isNameVisible, String name, String texture, boolean isTextureResourceLocation, boolean isSlim,
+  public CEditNpc(int entityid, boolean isNameVisible, String name, String title, String texture, boolean isTextureResourceLocation, boolean isSlim,
                   String dialogue, String behavior, int textColor, ItemStack[] items, NPCPose pose, EntityType<?> renderer,
                   CompoundTag rendererTag, float scaleX, float scaleY, float scaleZ) {
-    this(entityid, isNameVisible, name, texture, isTextureResourceLocation, isSlim, dialogue, behavior, textColor, items, pose, false, renderer,
+    this(entityid, isNameVisible, name, title, texture, isTextureResourceLocation, isSlim, dialogue, behavior, textColor, items, pose, false, renderer,
             rendererTag, scaleX, scaleY, scaleZ);
   }
 
-  public CEditNpc(int entityid, boolean isNameVisible, String name, String texture, boolean isTextureResourceLocation, boolean isSlim,
+  public CEditNpc(int entityid, boolean isNameVisible, String name, String title, String texture, boolean isTextureResourceLocation, boolean isSlim,
                   String dialogue, String behavior, int textColor, ItemStack[] items, NPCPose pose, boolean resetAI,
                   EntityType<?> renderer, CompoundTag rendererTag, float scaleX, float scaleY, float scaleZ) {
-    this(entityid, isNameVisible, name, texture, isTextureResourceLocation, isSlim, dialogue, behavior, textColor, items, pose, resetAI, EntityType.getKey(renderer).toString(),
+    this(entityid, isNameVisible, name, title, texture, isTextureResourceLocation, isSlim, dialogue, behavior, textColor, items, pose, resetAI, EntityType.getKey(renderer).toString(),
             rendererTag, scaleX, scaleY, scaleZ);
   }
 
-  public CEditNpc(int entityid, boolean isNameVisible, String name, String texture, boolean isTextureResourceLocation, boolean isSlim,
+  public CEditNpc(int entityid, boolean isNameVisible, String name, String title, String texture, boolean isTextureResourceLocation, boolean isSlim,
                   String dialogue, String behavior, int textColor, ItemStack[] items, NPCPose pose, boolean resetAI, String renderer,
                   CompoundTag rendererTag, float scaleX, float scaleY, float scaleZ) {
     this.entityid = entityid;
     this.isNameVisible = isNameVisible;
     this.name = name;
+    this.title = title;
     this.texture = texture;
     this.isTextureResourceLocation = isTextureResourceLocation;
     this.isSlim = isSlim;
@@ -76,6 +77,7 @@ public class CEditNpc {
     buf.writeInt(msg.entityid);
     buf.writeBoolean(msg.isNameVisible);
     buf.writeUtf(msg.name);
+    buf.writeUtf(msg.title);
     buf.writeUtf(msg.texture);
     buf.writeBoolean(msg.isTextureResourceLocation);
     buf.writeBoolean(msg.isSlim);
@@ -104,6 +106,7 @@ public class CEditNpc {
     int entityid = buf.readInt();
     boolean isNameVisible = buf.readBoolean();
     String name = buf.readUtf(201);
+    String title = buf.readUtf(201);
     String texture = buf.readUtf(201);
     boolean isTextureResourceLocation = buf.readBoolean();
     boolean isSlim = buf.readBoolean();
@@ -122,7 +125,7 @@ public class CEditNpc {
       items.add(buf.readItem());
     }
     return new CEditNpc(
-            entityid, isNameVisible, name, texture, isTextureResourceLocation, isSlim, dialogue, behavior, textColor, items.toArray(new ItemStack[0]),
+            entityid, isNameVisible, name, title, texture, isTextureResourceLocation, isSlim, dialogue, behavior, textColor, items.toArray(new ItemStack[0]),
             pose, resetAI, renderer, rendererTag, scaleX, scaleY, scaleZ
     );
   }
@@ -135,6 +138,7 @@ public class CEditNpc {
         if (entity instanceof NpcEntity npcEntity) {
           npcEntity.setCustomNameVisible(msg.isNameVisible);
           npcEntity.setCustomName(new TextComponent(msg.name));
+          npcEntity.setTitle(msg.title);
           npcEntity.setTexture(msg.texture);
           npcEntity.setIsTextureResourceLocation(msg.isTextureResourceLocation);
           npcEntity.setSlim(msg.isSlim);

--- a/src/main/java/flash/npcmod/network/packets/server/SAcceptQuest.java
+++ b/src/main/java/flash/npcmod/network/packets/server/SAcceptQuest.java
@@ -1,33 +1,41 @@
 package flash.npcmod.network.packets.server;
 
 import flash.npcmod.Main;
+import flash.npcmod.core.quests.QuestInstance;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraftforge.network.NetworkEvent;
 
+import java.util.UUID;
 import java.util.function.Supplier;
 
 public class SAcceptQuest {
 
   String name;
   int entityid;
+  UUID uuid;
+  QuestInstance.TurnInType turnInType;
 
-  public SAcceptQuest(String name, int entityid) {
+  public SAcceptQuest(String name, int entityid, QuestInstance.TurnInType turnInType, UUID uuid) {
     this.name = name;
     this.entityid = entityid;
+    this.turnInType = turnInType;
+    this.uuid = uuid;
   }
 
   public static void encode(SAcceptQuest msg, FriendlyByteBuf buf) {
     buf.writeUtf(msg.name);
     buf.writeInt(msg.entityid);
+    buf.writeInt(msg.turnInType.ordinal());
+    buf.writeUUID(msg.uuid);
   }
 
   public static SAcceptQuest decode(FriendlyByteBuf buf) {
-    return new SAcceptQuest(buf.readUtf(51), buf.readInt());
+    return new SAcceptQuest(buf.readUtf(51), buf.readInt(), QuestInstance.TurnInType.values()[buf.readInt()], buf.readUUID());
   }
 
   public static void handle(SAcceptQuest msg, Supplier<NetworkEvent.Context> ctx) {
     ctx.get().enqueueWork(() -> {
-      Main.PROXY.acceptQuest(msg.name, msg.entityid);
+      Main.PROXY.acceptQuest(msg.name, msg.entityid, msg.turnInType, msg.uuid);
     });
     ctx.get().setPacketHandled(true);
   }

--- a/src/main/java/flash/npcmod/network/packets/server/SSyncQuestCapability.java
+++ b/src/main/java/flash/npcmod/network/packets/server/SSyncQuestCapability.java
@@ -59,6 +59,7 @@ public class SSyncQuestCapability {
           buf.writeUtf(questInstance.getQuest().getName(), 51);
           buf.writeUUID(questInstance.getPickedUpFrom());
           buf.writeUtf(questInstance.getPickedUpFromName(), 200);
+          buf.writeInt(questInstance.getTurnInType().ordinal());
           for (int i = 0; i < questInstance.getQuest().getObjectives().size(); i++) {
             QuestObjective objective = questInstance.getQuest().getObjectives().get(i);
             buf.writeInt(objective.getId());
@@ -90,18 +91,10 @@ public class SSyncQuestCapability {
   public static void handle(SSyncQuestCapability msg, Supplier<NetworkEvent.Context> ctx) {
     ctx.get().enqueueWork(() -> {
       switch (msg.type) {
-        case TRACKED_QUEST:
-          Main.PROXY.syncTrackedQuest(msg.trackedQuest);
-          break;
-        case ACCEPTED_QUESTS:
-          Main.PROXY.syncAcceptedQuests(new ArrayList<>(Arrays.asList(msg.acceptedQuests)));
-          break;
-        case COMPLETED_QUESTS:
-          Main.PROXY.syncCompletedQuests(new ArrayList<>(Arrays.asList(msg.completedQuests)));
-          break;
-        case PROGRESS_MAP:
-          Main.PROXY.syncQuestProgressMap(msg.objectiveProgressMap);
-          break;
+        case TRACKED_QUEST -> Main.PROXY.syncTrackedQuest(msg.trackedQuest);
+        case ACCEPTED_QUESTS -> Main.PROXY.syncAcceptedQuests(new ArrayList<>(Arrays.asList(msg.acceptedQuests)));
+        case COMPLETED_QUESTS -> Main.PROXY.syncCompletedQuests(new ArrayList<>(Arrays.asList(msg.completedQuests)));
+        case PROGRESS_MAP -> Main.PROXY.syncQuestProgressMap(msg.objectiveProgressMap);
       }
     });
     ctx.get().setPacketHandled(true);


### PR DESCRIPTION
- Command to reset all quest progress for specified player: `/flashnpcs quests reset @p all`
- Reset specific quest progress command has been reformatted: `/flashnpcs quests reset @p quest <quest_internal_name>`
- `CraftItem` quest objective type
- `acceptQuest` function now asks for two optional parameters: `turnInType` and `turnInUuid`.
  - `turnInType` can be either `auto` or `npc`
    - `auto` means the quest will be automatically turned in when all objectives are complete, must not input `turnInUuid`
    - `npc` requires the third parameter `turnInUuid`, which is the uuid of the npc the player has to turn the quest in at
    - by default, the turn in type is `questgiver`, meaning the player has to turn in the quest at the npc they got it from
- Fixed entity dropdown in `QuestObjectiveBuilder` resetting to default value (`pig`) when opening the gui with an objective passed in as a parameter
- Added npc titles that appear below the npc's name in italic if their name is visible
- Fixed npc eye level