### PR TITLE
1.18 - functions

### DIFF
--- a/src/main/java/flash/npcmod/CommonProxy.java
+++ b/src/main/java/flash/npcmod/CommonProxy.java
@@ -49,4 +49,5 @@ public class CommonProxy {
 
   public void loadEntities(String[] entities) {}
 
+  public void getQuestInfo(String name, String questInfo) {}
 }

--- a/src/main/java/flash/npcmod/client/gui/screen/TreeBuilderScreen.java
+++ b/src/main/java/flash/npcmod/client/gui/screen/TreeBuilderScreen.java
@@ -403,7 +403,6 @@ abstract public class TreeBuilderScreen extends Screen {
                 confirmEdits();
                 this.getEditingNode().calculateDimensions();
             }
-            Main.LOGGER.info("Confirm hit");
             this.setNodeBeingEdited(null, EditType.NONE);
         }));
         this.cancelButton = this.addWidget(new Button(width / 2 + 10, height / 2 + 15, 50, 20, new TextComponent("Cancel"),
@@ -457,6 +456,20 @@ abstract public class TreeBuilderScreen extends Screen {
         this.functionParamsField.setVisible(false);
         this.functionParamsField.setCanLoseFocus(true);
         this.functionListWidget.setVisible(false);
+    }
+
+    @Override
+    public boolean keyPressed(int p_96552_, int p_96553_, int p_96554_) {
+        if (p_96552_ == 256 && !shouldCloseOnEsc()) {
+            this.setNodeBeingEdited(null, EditType.NONE);
+            return true;
+        }
+        return super.keyPressed(p_96552_, p_96553_, p_96554_);
+    }
+
+    @Override
+    public boolean shouldCloseOnEsc() {
+        return !isAnyTextFieldVisible();
     }
 
     /**

--- a/src/main/java/flash/npcmod/client/gui/screen/dialogue/DialogueScreen.java
+++ b/src/main/java/flash/npcmod/client/gui/screen/dialogue/DialogueScreen.java
@@ -14,6 +14,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
 import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.util.FormattedCharSequence;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -145,7 +146,7 @@ public class DialogueScreen extends Screen {
     displayedText.add(splitTextIntoLines(newText));
   }
 
-  private String[] splitTextIntoLines(String text) {
+  public static String[] splitTextIntoLines(String text) {
     if (text.contains("\\n")) {
       List<String> lines = new ArrayList<>();
       while (text.contains("\\n")) {

--- a/src/main/java/flash/npcmod/client/gui/screen/dialogue/DialogueScreen.java
+++ b/src/main/java/flash/npcmod/client/gui/screen/dialogue/DialogueScreen.java
@@ -18,16 +18,16 @@ import net.minecraft.util.FormattedCharSequence;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @OnlyIn(Dist.CLIENT)
 public class DialogueScreen extends Screen {
 
   private static final Random RND = new Random();
 
-  public List<String> displayedText;
+  public List<String[]> displayedText;
   private String[] currentOptions, currentOptionNames;
 
   private final NpcEntity npcEntity;
@@ -35,7 +35,7 @@ public class DialogueScreen extends Screen {
 
   private int npcTextColor;
   private String dialogueName;
-  private String playerName;
+  public String playerName;
 
   public DialogueScreen(String name, NpcEntity npcEntity) {
     super(TextComponent.EMPTY);
@@ -142,7 +142,22 @@ public class DialogueScreen extends Screen {
 
   private void addDisplayedText(String name, String text) {
     String newText = name + ": " + text.replaceAll("@p", playerName).replaceAll("@npc", getNpcName());
-    displayedText.add(newText);
+    displayedText.add(splitTextIntoLines(newText));
+  }
+
+  private String[] splitTextIntoLines(String text) {
+    if (text.contains("\\n")) {
+      List<String> lines = new ArrayList<>();
+      while (text.contains("\\n")) {
+        int index = text.lastIndexOf("\\n");
+        String s = text.substring(index + 2);
+        lines.add(s);
+        text = text.substring(0, index);
+      }
+      lines.add(text);
+      return lines.toArray(String[]::new);
+    }
+    return new String[]{text};
   }
 
   @Override

--- a/src/main/java/flash/npcmod/client/gui/screen/quests/QuestEditorScreen.java
+++ b/src/main/java/flash/npcmod/client/gui/screen/quests/QuestEditorScreen.java
@@ -185,7 +185,7 @@ public class QuestEditorScreen extends Screen {
     this.loadButton = this.addRenderableWidget(new Button(width-105, 30, 100, 20, new TextComponent("Load"), btn -> {
       if (!questToLoad.isEmpty()) {
         PacketDispatcher.sendToServer(new CRequestQuestInfo(questToLoad));
-        Quest quest = ClientQuestUtil.fromName(questToLoad);
+        Quest quest = ClientQuestUtil.loadQuest(questToLoad);
         if (quest != null) {
           QuestEditorScreen questEditorScreen = QuestEditorScreen.fromQuest(quest);
           questEditorScreen.updateObjectiveId();

--- a/src/main/java/flash/npcmod/client/gui/screen/quests/QuestObjectiveBuilderScreen.java
+++ b/src/main/java/flash/npcmod/client/gui/screen/quests/QuestObjectiveBuilderScreen.java
@@ -286,7 +286,6 @@ public class QuestObjectiveBuilderScreen extends Screen {
 
   private String getActualEntityObjective() {
     String actualEntityObjective = EntityType.getKey(entityObjective) + "::" + entityObjectiveTag.getAsString();
-    Main.LOGGER.debug(actualEntityObjective);
     return actualEntityObjective;
   }
 

--- a/src/main/java/flash/npcmod/client/gui/widget/DialogueDisplayWidget.java
+++ b/src/main/java/flash/npcmod/client/gui/widget/DialogueDisplayWidget.java
@@ -40,7 +40,7 @@ public class DialogueDisplayWidget extends AbstractWidget {
     int prevHeight = 0;
     for (int i = screen.displayedText.size()-1-scrollY; i >= 0; i--) {
       String[] lines = screen.displayedText.get(i);
-      int textColor = lines[0].startsWith(screen.playerName) ? 0xFFFFFF : screen.getNpcTextColor();
+      int textColor = lines[lines.length-1].startsWith(screen.playerName) ? 0xFFFFFF : screen.getNpcTextColor();
       int lineHeight = fontrenderer.lineHeight+1;
 
       for (String line : lines) {

--- a/src/main/java/flash/npcmod/client/gui/widget/DialogueDisplayWidget.java
+++ b/src/main/java/flash/npcmod/client/gui/widget/DialogueDisplayWidget.java
@@ -2,6 +2,7 @@ package flash.npcmod.client.gui.widget;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
+import flash.npcmod.Main;
 import flash.npcmod.client.gui.screen.dialogue.DialogueScreen;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
@@ -14,6 +15,7 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 @OnlyIn(Dist.CLIENT)
 public class DialogueDisplayWidget extends AbstractWidget {
@@ -37,13 +39,20 @@ public class DialogueDisplayWidget extends AbstractWidget {
     RenderSystem.enableDepthTest();
     int prevHeight = 0;
     for (int i = screen.displayedText.size()-1-scrollY; i >= 0; i--) {
-      List<FormattedCharSequence> trimmedText = fontrenderer.split(new TextComponent(screen.displayedText.get(i)), width);
-
+      String[] lines = screen.displayedText.get(i);
+      int textColor = lines[0].startsWith(screen.playerName) ? 0xFFFFFF : screen.getNpcTextColor();
       int lineHeight = fontrenderer.lineHeight+1;
 
-      drawMultilineText(matrixStack, trimmedText, fontrenderer, x, y+height-prevHeight-lineHeight*trimmedText.size(), (i & 1) == 0 ? screen.getNpcTextColor() : 0xFFFFFF);
-
-      prevHeight += lineHeight*trimmedText.size()+lineHeight;
+      for (String line : lines) {
+        if (line.isEmpty()) {
+          prevHeight += lineHeight;
+        } else {
+          List<FormattedCharSequence> trimmedText = fontrenderer.split(new TextComponent(line), width);
+          drawMultilineText(matrixStack, trimmedText, fontrenderer, x, y + height - prevHeight - lineHeight * trimmedText.size(), textColor);
+          prevHeight += lineHeight * trimmedText.size();
+        }
+      }
+      prevHeight += lineHeight;
     }
     matrixStack.popPose();
   }
@@ -73,9 +82,12 @@ public class DialogueDisplayWidget extends AbstractWidget {
     int lineHeight = fontRenderer.lineHeight+1;
     int numOfLines = 0;
     for (int i = 0; i < screen.displayedText.size(); i++) {
-      List<FormattedCharSequence> trimmedText = fontRenderer.split(new TextComponent(screen.displayedText.get(i)), width);
-
-      numOfLines += trimmedText.size()+1;
+      String[] lines = screen.displayedText.get(i);
+      for (String line : lines) {
+        List<FormattedCharSequence> trimmedText = fontRenderer.split(new TextComponent(line), width);
+        numOfLines += trimmedText.size();
+      }
+      numOfLines += 1;
     }
     int maxLinesInHeight = height/lineHeight;
     int max = numOfLines - maxLinesInHeight;

--- a/src/main/java/flash/npcmod/client/gui/widget/TextButton.java
+++ b/src/main/java/flash/npcmod/client/gui/widget/TextButton.java
@@ -2,6 +2,7 @@ package flash.npcmod.client.gui.widget;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
+import flash.npcmod.client.gui.screen.dialogue.DialogueScreen;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.components.Button;
@@ -13,16 +14,25 @@ import net.minecraft.util.Mth;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @OnlyIn(Dist.CLIENT)
 public class TextButton extends Button {
-  List<FormattedCharSequence> trimmedText;
+  List<List<FormattedCharSequence>> trimmedTexts;
 
   public TextButton(int x, int y, int width, Component title, OnPress pressedAction) {
     super(x, y, width, 9, title, pressedAction);
-    trimmedText = Minecraft.getInstance().font.split(new TextComponent("> " + title.getString()), width);
-    this.setHeight(9 * trimmedText.size());
+    trimmedTexts = new ArrayList<>();
+    String[] lines = DialogueScreen.splitTextIntoLines(title.getString());
+    int height = 0;
+    for (int i = lines.length - 1; i >= 0; i--) {
+      String line = i == lines.length - 1 ? "> " + lines[i] : lines[i];
+      List<FormattedCharSequence> trimmedText = Minecraft.getInstance().font.split(new TextComponent(line), width);
+      trimmedTexts.add(trimmedText);
+      height += 9 * trimmedText.size();
+    }
+    this.setHeight(height);
   }
 
   @Override
@@ -46,10 +56,15 @@ public class TextButton extends Button {
   }
 
   private void drawMultilineText(PoseStack matrixStack, Font font, int x, int y, int color) {
-    for (int i = 0; i < trimmedText.size(); i++) {
-      FormattedCharSequence processor = trimmedText.get(i);
-      int j = i > 0 ? 4 : 0;
-      font.draw(matrixStack, processor, x+j, y+((font.lineHeight+1)*i), color);
+    int h = 0;
+    for (int i = 0; i < trimmedTexts.size(); i++) {
+      List<FormattedCharSequence> trimmedText = trimmedTexts.get(i);
+      for (int j = 0; j < trimmedText.size(); j++) {
+        FormattedCharSequence processor = trimmedText.get(j);
+        int k = i != 0 || j > 0 ? 4 : 0;
+        font.draw(matrixStack, processor, x+k, y+h, color);
+        h += font.lineHeight + 1;
+      }
     }
   }
 }

--- a/src/main/java/flash/npcmod/commands/DebugCommand.java
+++ b/src/main/java/flash/npcmod/commands/DebugCommand.java
@@ -31,14 +31,15 @@ public class DebugCommand extends Command {
 
   @Override
   public void build(LiteralArgumentBuilder<CommandSourceStack> builder) {
-    builder.then(argument("player", EntityArgument.player())
+    builder.then(literal("player")
+            .then(argument("player", EntityArgument.player())
             .then(literal("capability")
                     .then(literal("quests")
                             .then(literal("tracked").executes(context -> tracked(context.getSource(), EntityArgument.getPlayer(context, "player"))))
                             .then(literal("accepted").executes(context -> accepted(context.getSource(), EntityArgument.getPlayer(context, "player"))))
                             .then(literal("completed").executes(context -> completed(context.getSource(), EntityArgument.getPlayer(context, "player"))))
                     )
-            )
+            ))
     );
 
     builder.then(literal("functions").executes(context -> toggleFunctionDebugMode(context.getSource())));

--- a/src/main/java/flash/npcmod/commands/DebugCommand.java
+++ b/src/main/java/flash/npcmod/commands/DebugCommand.java
@@ -3,8 +3,10 @@ package flash.npcmod.commands;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import flash.npcmod.capability.quests.IQuestCapability;
 import flash.npcmod.capability.quests.QuestCapabilityProvider;
+import flash.npcmod.core.functions.FunctionUtil;
 import flash.npcmod.core.quests.Quest;
 import flash.npcmod.core.quests.QuestInstance;
+import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.arguments.EntityArgument;
 import net.minecraft.network.chat.TextComponent;
@@ -38,6 +40,8 @@ public class DebugCommand extends Command {
                     )
             )
     );
+
+    builder.then(literal("functions").executes(context -> toggleFunctionDebugMode(context.getSource())));
   }
 
   @Override
@@ -82,6 +86,13 @@ public class DebugCommand extends Command {
       source.sendSuccess(new TextComponent(sb.toString()), false);
       return 1;
     }
+    return 0;
+  }
+
+  private int toggleFunctionDebugMode(CommandSourceStack source) {
+    FunctionUtil.toggleDebugMode();
+    boolean debugMode = FunctionUtil.isDebugMode();
+    source.sendSuccess(new TextComponent("Toggled Debug Mode to " + debugMode).withStyle(debugMode ? ChatFormatting.GREEN : ChatFormatting.RED), true);
     return 0;
   }
 }

--- a/src/main/java/flash/npcmod/core/FileUtil.java
+++ b/src/main/java/flash/npcmod/core/FileUtil.java
@@ -84,7 +84,7 @@ public class FileUtil {
     if (globalFile != null && globalFile.exists()) {
       return globalFile;
     }
-    return getJsonFileForWriting(path, name);
+    return getFileForWriting(path, name, extension);
   }
 
   private static File getFileForWriting(String path, String name, String extension) {

--- a/src/main/java/flash/npcmod/core/client/dialogues/ClientDialogueUtil.java
+++ b/src/main/java/flash/npcmod/core/client/dialogues/ClientDialogueUtil.java
@@ -57,7 +57,9 @@ public class ClientDialogueUtil {
 
       currentDialogue = FileUtil.GSON.fromJson(is, JsonObject.class);
       is.close();
+      Main.LOGGER.debug("Loaded dialogue file " + name);
     } catch (Exception e) {
+      Main.LOGGER.debug("Requesting dialogue file " + name);
       PacketDispatcher.sendToServer(new CRequestDialogue(name));
     }
   }
@@ -89,21 +91,18 @@ public class ClientDialogueUtil {
     if (!currentObject.has("entries")) {
       boolean result;
       if (name.equals(currentObject.get("name").getAsString())) {
+        currentDialogue = currentObject;
         setVars(currentObject);
         return true;
-      } else {
-        if (currentObject.has("children")) {
-          JsonArray children = currentObject.getAsJsonArray("children");
-          for (int i = 0; i < children.size(); i++) {
-            JsonObject currentChild = children.get(i).getAsJsonObject();
+      } else if (currentObject.has("children")) {
+        JsonArray children = currentObject.getAsJsonArray("children");
+        for (int i = 0; i < children.size(); i++) {
+          JsonObject currentChild = children.get(i).getAsJsonObject();
 
-            result = findText(name, currentChild);
+          result = findText(name, currentChild);
 
-            if (result) {
-              currentDialogue = currentChild;
-              setVars(currentChild);
-              return true;
-            }
+          if (result) {
+            return true;
           }
         }
       }
@@ -133,7 +132,6 @@ public class ClientDialogueUtil {
   }
 
   private static void setVars(JsonObject object) {
-
     currentText = object.get("text").getAsString();
     if (object.has("response")) {
       currentResponse = object.get("response").getAsString();
@@ -150,7 +148,6 @@ public class ClientDialogueUtil {
     } else {
       currentTrigger = "";
     }
-    Main.LOGGER.info("current trigger is " + currentTrigger);
     if (object.has("children")) {
       currentChildren = object.getAsJsonArray("children");
     } else {

--- a/src/main/java/flash/npcmod/core/client/quests/ClientQuestUtil.java
+++ b/src/main/java/flash/npcmod/core/client/quests/ClientQuestUtil.java
@@ -3,8 +3,6 @@ package flash.npcmod.core.client.quests;
 import com.google.gson.JsonObject;
 import flash.npcmod.core.FileUtil;
 import flash.npcmod.core.quests.Quest;
-import flash.npcmod.network.PacketDispatcher;
-import flash.npcmod.network.packets.client.CRequestQuestInfo;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
@@ -12,37 +10,18 @@ import javax.annotation.Nullable;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
 
 @OnlyIn(Dist.CLIENT)
 public class ClientQuestUtil {
 
-  public static final List<Quest> QUESTS = new ArrayList<>();
-
-  @Nullable
-  public static Quest fromName(String name) {
-    for (Quest quest : QUESTS) {
-      if (quest.getName().equals(name))
-        return quest;
-    }
-
-    return loadQuest(name);
-  }
-
   @Nullable
   public static Quest loadQuest(String name) {
-    PacketDispatcher.sendToServer(new CRequestQuestInfo(name));
     try {
       InputStreamReader is = new InputStreamReader(new FileInputStream(FileUtil.getJsonFile("quests", name)), StandardCharsets.UTF_8);
       JsonObject object = FileUtil.GSON.fromJson(is, JsonObject.class);
-
-      Quest quest = Quest.fromJson(object);
-      QUESTS.remove(quest);
-
-      QUESTS.add(quest);
       is.close();
-      return quest;
+
+      return Quest.fromJson(object);
     } catch (Exception ignored) {}
 
     return null;

--- a/src/main/java/flash/npcmod/core/functions/AbstractFunction.java
+++ b/src/main/java/flash/npcmod/core/functions/AbstractFunction.java
@@ -2,7 +2,11 @@ package flash.npcmod.core.functions;
 
 import flash.npcmod.Main;
 import flash.npcmod.entity.NpcEntity;
+import net.minecraft.Util;
+import net.minecraft.network.chat.ChatType;
+import net.minecraft.network.chat.TextComponent;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.server.ServerLifecycleHooks;
 
 public abstract class AbstractFunction {
   protected static final String[] empty = new String[0];
@@ -31,8 +35,12 @@ public abstract class AbstractFunction {
     return paramNames;
   }
 
-  protected void warnParameterAmount(NpcEntity npcEntity) {
-    Main.LOGGER.warn("Function " + name + " in " + npcEntity.getName().getString() + " does not have the right amount of parameters");
+  protected void warnParameterAmount(ServerPlayer sender, NpcEntity npcEntity) {
+    String warningMessage = "Function " + name + " in " + npcEntity.getName().getString() + " does not have the right amount of parameters";
+    if (FunctionUtil.isDebugMode()) {
+      sender.sendMessage(new TextComponent("[FlashNPCs] ".concat(warningMessage)), ChatType.SYSTEM, Util.NIL_UUID);
+    }
+    Main.LOGGER.warn(warningMessage);
   }
 
   protected void debugUsage(ServerPlayer sender, NpcEntity npcEntity) {

--- a/src/main/java/flash/npcmod/core/functions/Function.java
+++ b/src/main/java/flash/npcmod/core/functions/Function.java
@@ -39,7 +39,7 @@ public class Function extends AbstractFunction {
           command = FunctionUtil.replaceSelectors(command, sender, npcEntity);
 
           MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
-          CommandSourceStack source = server.createCommandSourceStack();
+          CommandSourceStack source = npcEntity.createCommandSourceStack().withPermission(4);
           if (!FunctionUtil.isDebugMode()) {
             source = source.withSuppressedOutput();
           }

--- a/src/main/java/flash/npcmod/core/functions/Function.java
+++ b/src/main/java/flash/npcmod/core/functions/Function.java
@@ -2,6 +2,7 @@ package flash.npcmod.core.functions;
 
 import flash.npcmod.config.ConfigHolder;
 import flash.npcmod.entity.NpcEntity;
+import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.server.ServerLifecycleHooks;
@@ -38,12 +39,16 @@ public class Function extends AbstractFunction {
           command = FunctionUtil.replaceSelectors(command, sender, npcEntity);
 
           MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
-          server.getCommands().performCommand(server.createCommandSourceStack().withSuppressedOutput(), command);
+          CommandSourceStack source = server.createCommandSourceStack();
+          if (!FunctionUtil.isDebugMode()) {
+            source = source.withSuppressedOutput();
+          }
+          server.getCommands().performCommand(source, command);
         }
       }
       debugUsage(sender, npcEntity);
     } else {
-      warnParameterAmount(npcEntity);
+      warnParameterAmount(sender, npcEntity);
     }
   }
 }

--- a/src/main/java/flash/npcmod/core/functions/FunctionUtil.java
+++ b/src/main/java/flash/npcmod/core/functions/FunctionUtil.java
@@ -14,6 +14,8 @@ import java.util.List;
 
 public class FunctionUtil {
 
+  private static boolean DEBUG_MODE = false;
+
   public static final List<AbstractFunction> FUNCTIONS = new ArrayList<>();
 
   private static final AcceptQuestFunction ACCEPT_QUEST = new AcceptQuestFunction();
@@ -40,6 +42,14 @@ public class FunctionUtil {
     FUNCTIONS.add(OPEN_TRADES);
     FUNCTIONS.add(PLAY_SOUND);
     FUNCTIONS.add(RANDOM_OPTION);
+  }
+
+  public static void toggleDebugMode() {
+    DEBUG_MODE = !DEBUG_MODE;
+  }
+
+  public static boolean isDebugMode() {
+    return DEBUG_MODE;
   }
 
   public static void build(String name, String function) {

--- a/src/main/java/flash/npcmod/core/functions/FunctionUtil.java
+++ b/src/main/java/flash/npcmod/core/functions/FunctionUtil.java
@@ -21,6 +21,8 @@ public class FunctionUtil {
   private static final MoveOnAcceptedQuestFunction MOVE_ON_ACCEPTED_QUEST = new MoveOnAcceptedQuestFunction();
   private static final MoveOnCompleteQuestFunction MOVE_ON_COMPLETE_QUEST = new MoveOnCompleteQuestFunction();
   private static final MoveOnScoreboardFunction MOVE_ON_SCOREBOARD = new MoveOnScoreboardFunction();
+  private static final MoveOnTagFunction MOVE_ON_TAG = new MoveOnTagFunction();
+  private static final MoveOnTeamFunction MOVE_ON_TEAM = new MoveOnTeamFunction();
   private static final MoveToDialogueFunction MOVE_TO_DIALOGUE = new MoveToDialogueFunction();
   private static final OpenTradesFunction OPEN_TRADES = new OpenTradesFunction();
   private static final PlaySoundFunction PLAY_SOUND = new PlaySoundFunction();
@@ -32,6 +34,8 @@ public class FunctionUtil {
     FUNCTIONS.add(MOVE_ON_ACCEPTED_QUEST);
     FUNCTIONS.add(MOVE_ON_COMPLETE_QUEST);
     FUNCTIONS.add(MOVE_ON_SCOREBOARD);
+    FUNCTIONS.add(MOVE_ON_TAG);
+    FUNCTIONS.add(MOVE_ON_TEAM);
     FUNCTIONS.add(MOVE_TO_DIALOGUE);
     FUNCTIONS.add(OPEN_TRADES);
     FUNCTIONS.add(PLAY_SOUND);

--- a/src/main/java/flash/npcmod/core/functions/defaultfunctions/AcceptQuestFunction.java
+++ b/src/main/java/flash/npcmod/core/functions/defaultfunctions/AcceptQuestFunction.java
@@ -31,7 +31,7 @@ public class AcceptQuestFunction extends AbstractFunction {
       }
       debugUsage(sender, npcEntity);
     } else {
-      warnParameterAmount(npcEntity);
+      warnParameterAmount(sender, npcEntity);
     }
   }
 

--- a/src/main/java/flash/npcmod/core/functions/defaultfunctions/MoveOnAcceptedQuestFunction.java
+++ b/src/main/java/flash/npcmod/core/functions/defaultfunctions/MoveOnAcceptedQuestFunction.java
@@ -30,7 +30,7 @@ public class MoveOnAcceptedQuestFunction extends AbstractFunction {
 
       debugUsage(sender, npcEntity);
     } else {
-      warnParameterAmount(npcEntity);
+      warnParameterAmount(sender, npcEntity);
     }
   }
 }

--- a/src/main/java/flash/npcmod/core/functions/defaultfunctions/MoveOnCompleteQuestFunction.java
+++ b/src/main/java/flash/npcmod/core/functions/defaultfunctions/MoveOnCompleteQuestFunction.java
@@ -25,7 +25,7 @@ public class MoveOnCompleteQuestFunction extends AbstractFunction {
 
       debugUsage(sender, npcEntity);
     } else {
-      warnParameterAmount(npcEntity);
+      warnParameterAmount(sender, npcEntity);
     }
   }
 }

--- a/src/main/java/flash/npcmod/core/functions/defaultfunctions/MoveOnScoreboardFunction.java
+++ b/src/main/java/flash/npcmod/core/functions/defaultfunctions/MoveOnScoreboardFunction.java
@@ -44,7 +44,7 @@ public class MoveOnScoreboardFunction extends AbstractFunction {
         debugUsage(sender, npcEntity);
       }
     } else {
-      warnParameterAmount(npcEntity);
+      warnParameterAmount(sender, npcEntity);
     }
   }
 }

--- a/src/main/java/flash/npcmod/core/functions/defaultfunctions/MoveOnTagFunction.java
+++ b/src/main/java/flash/npcmod/core/functions/defaultfunctions/MoveOnTagFunction.java
@@ -1,0 +1,30 @@
+package flash.npcmod.core.functions.defaultfunctions;
+
+import flash.npcmod.core.functions.AbstractFunction;
+import flash.npcmod.entity.NpcEntity;
+import flash.npcmod.network.PacketDispatcher;
+import flash.npcmod.network.packets.server.SMoveToDialogue;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.scores.PlayerTeam;
+
+public class MoveOnTagFunction extends AbstractFunction {
+
+  public MoveOnTagFunction() {
+    super("moveOnTag", new String[]{"tag", "trueOption", "falseOption"}, empty);
+  }
+
+  @Override
+  public void call(String[] params, ServerPlayer sender, NpcEntity npcEntity) {
+    if (params.length == 3) {
+      String tag = params[0];
+      if (sender.getTags().contains(tag))
+        PacketDispatcher.sendTo(new SMoveToDialogue(params[1], npcEntity.getId()), sender);
+      else
+        PacketDispatcher.sendTo(new SMoveToDialogue(params[2], npcEntity.getId()), sender);
+
+      debugUsage(sender, npcEntity);
+    } else {
+      warnParameterAmount(npcEntity);
+    }
+  }
+}

--- a/src/main/java/flash/npcmod/core/functions/defaultfunctions/MoveOnTagFunction.java
+++ b/src/main/java/flash/npcmod/core/functions/defaultfunctions/MoveOnTagFunction.java
@@ -24,7 +24,7 @@ public class MoveOnTagFunction extends AbstractFunction {
 
       debugUsage(sender, npcEntity);
     } else {
-      warnParameterAmount(npcEntity);
+      warnParameterAmount(sender, npcEntity);
     }
   }
 }

--- a/src/main/java/flash/npcmod/core/functions/defaultfunctions/MoveOnTeamFunction.java
+++ b/src/main/java/flash/npcmod/core/functions/defaultfunctions/MoveOnTeamFunction.java
@@ -1,0 +1,33 @@
+package flash.npcmod.core.functions.defaultfunctions;
+
+import flash.npcmod.core.functions.AbstractFunction;
+import flash.npcmod.entity.NpcEntity;
+import flash.npcmod.network.PacketDispatcher;
+import flash.npcmod.network.packets.server.SMoveToDialogue;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.scores.Objective;
+import net.minecraft.world.scores.PlayerTeam;
+
+public class MoveOnTeamFunction extends AbstractFunction {
+
+  public MoveOnTeamFunction() {
+    super("moveOnTeam", new String[]{"team", "trueOption", "falseOption"}, empty);
+  }
+
+  @Override
+  public void call(String[] params, ServerPlayer sender, NpcEntity npcEntity) {
+    if (params.length == 3) {
+      PlayerTeam team = sender.getScoreboard().getPlayerTeam(params[0]);
+      if (team != null) {
+        if (team.getPlayers().contains(sender.getScoreboardName()))
+          PacketDispatcher.sendTo(new SMoveToDialogue(params[1], npcEntity.getId()), sender);
+        else
+          PacketDispatcher.sendTo(new SMoveToDialogue(params[2], npcEntity.getId()), sender);
+
+        debugUsage(sender, npcEntity);
+      }
+    } else {
+      warnParameterAmount(npcEntity);
+    }
+  }
+}

--- a/src/main/java/flash/npcmod/core/functions/defaultfunctions/MoveOnTeamFunction.java
+++ b/src/main/java/flash/npcmod/core/functions/defaultfunctions/MoveOnTeamFunction.java
@@ -27,7 +27,7 @@ public class MoveOnTeamFunction extends AbstractFunction {
         debugUsage(sender, npcEntity);
       }
     } else {
-      warnParameterAmount(npcEntity);
+      warnParameterAmount(sender, npcEntity);
     }
   }
 }

--- a/src/main/java/flash/npcmod/core/functions/defaultfunctions/MoveToDialogueFunction.java
+++ b/src/main/java/flash/npcmod/core/functions/defaultfunctions/MoveToDialogueFunction.java
@@ -18,7 +18,7 @@ public class MoveToDialogueFunction extends AbstractFunction {
       PacketDispatcher.sendTo(new SMoveToDialogue(params[0], npcEntity.getId()), sender);
       debugUsage(sender, npcEntity);
     } else {
-      warnParameterAmount(npcEntity);
+      warnParameterAmount(sender, npcEntity);
     }
   }
 }

--- a/src/main/java/flash/npcmod/core/functions/defaultfunctions/PlaySoundFunction.java
+++ b/src/main/java/flash/npcmod/core/functions/defaultfunctions/PlaySoundFunction.java
@@ -25,10 +25,9 @@ public class PlaySoundFunction extends AbstractFunction {
         sender.connection.send(new ClientboundCustomSoundPacket(sound, SoundSource.MASTER, new Vec3(x, y, z), 1f, 1f));
         debugUsage(sender, npcEntity);
       } else {
-        warnParameterAmount(npcEntity);
+        warnParameterAmount(sender, npcEntity);
       }
-    } catch (NumberFormatException e) {
-      return;
+    } catch (NumberFormatException ignored) {
     }
   }
 }

--- a/src/main/java/flash/npcmod/core/quests/CommonQuestUtil.java
+++ b/src/main/java/flash/npcmod/core/quests/CommonQuestUtil.java
@@ -43,7 +43,7 @@ public class CommonQuestUtil {
       List<QuestInstance> acceptedQuests = capability.getAcceptedQuests();
       List<QuestInstance> markedForRemoval = new ArrayList<>();
       acceptedQuests.forEach(questInstance -> {
-        JsonObject quest = loadQuest(questInstance.getQuest().getName());
+        JsonObject quest = loadQuestAsJson(questInstance.getQuest().getName());
         if (quest != null) {
           PacketDispatcher.sendTo(new SSendQuestInfo(questInstance.getQuest().getName(), quest.toString()), player);
         } else {
@@ -57,6 +57,7 @@ public class CommonQuestUtil {
   }
 
   public static void buildQuest(String name, String jsonText) {
+    removeQuest(name);
     try {
       File jsonFile = FileUtil.getJsonFileForWriting("quests", name);
       JsonObject jsonObject = FileUtil.GSON.fromJson(jsonText, JsonObject.class);
@@ -85,7 +86,7 @@ public class CommonQuestUtil {
   }
 
   @Nullable
-  public static JsonObject loadQuest(String name) {
+  public static JsonObject loadQuestAsJson(String name) {
     Quest fromName = fromName(name);
     if (fromName != null) return fromName.toJson();
 
@@ -100,8 +101,7 @@ public class CommonQuestUtil {
       is.close();
 
       Quest quest = Quest.fromJson(object);
-      QUESTS.remove(quest);
-
+      removeQuest(name);
       QUESTS.add(quest);
 
       return quest;
@@ -111,6 +111,18 @@ public class CommonQuestUtil {
     }
 
     return null;
+  }
+
+  private static void removeQuest(String name) {
+    int toRemoveIndex = -1;
+    for (int i = 0; i < QUESTS.size(); i++) {
+      if (QUESTS.get(i).getName().equals(name)) {
+        toRemoveIndex = i;
+        break;
+      }
+    }
+    if (toRemoveIndex != -1)
+      QUESTS.remove(toRemoveIndex);
   }
 
 }

--- a/src/main/java/flash/npcmod/core/quests/QuestObjective.java
+++ b/src/main/java/flash/npcmod/core/quests/QuestObjective.java
@@ -293,7 +293,6 @@ public abstract class QuestObjective {
   }
 
   public static QuestObjective fromJson(JsonObject jsonObject) {
-    Main.LOGGER.debug("Loading quest from json");
     int id = jsonObject.get("index").getAsInt();
     String objectiveName = jsonObject.get("name").getAsString();
     int type = Mth.clamp(jsonObject.get("type").getAsInt(), 0, QuestObjective.ObjectiveType.values().length);

--- a/src/main/java/flash/npcmod/core/quests/QuestObjectiveTypes.java
+++ b/src/main/java/flash/npcmod/core/quests/QuestObjectiveTypes.java
@@ -56,7 +56,6 @@ public class QuestObjectiveTypes {
     public KillObjective(int id, String name, String entityObjective, int amount) {
       super(id, name, ObjectiveType.Kill, amount);
       this.entityObjective = entityObjective;
-      Main.LOGGER.debug("Creating kill objective with " + entityObjective);
       Pair<String, CompoundTag> keyAndTagPair = getEntityObjectiveFromString(entityObjective);
       this.livingEntityKey = keyAndTagPair.getFirst();
       this.livingEntityTag = keyAndTagPair.getSecond();
@@ -82,7 +81,6 @@ public class QuestObjectiveTypes {
 
     @Override
     public KillObjective copy() {
-      Main.LOGGER.debug("Creating killObjective copy");
       KillObjective copy = new KillObjective(getId(), getName(), entityObjective, getAmount());
       copyTo(copy);
       return copy;

--- a/src/main/java/flash/npcmod/events/QuestEvents.java
+++ b/src/main/java/flash/npcmod/events/QuestEvents.java
@@ -324,18 +324,11 @@ public class QuestEvents {
   }
 
   private static boolean areEntitiesEqual(Entity entity, QuestObjective objective) {
-    String entityKey = EntityType.getKey(entity.getType()).toString();
-    CompoundTag entityTag = entity.saveWithoutId(new CompoundTag());
     switch (objective.getType()) {
       case Kill -> {
         QuestObjectiveTypes.KillObjective killObjective = (QuestObjectiveTypes.KillObjective) objective;
-        boolean areTagsValid = doesTagContainTag(entityTag, killObjective.getEntityTag());
-        boolean areKeysValid = entityKey.equals(killObjective.getEntityKey());
-        Main.LOGGER.debug("Killed entity " + entityKey + "  " + entityTag.getAsString());
-        Main.LOGGER.debug("Objective key: " + killObjective.getEntityKey() + ", is valid:" + areKeysValid);
-        Main.LOGGER.debug("Objective tag: " + killObjective.getEntityTag().getAsString() + ", is valid:" + areTagsValid);
-        return areKeysValid
-                && areTagsValid;
+        return EntityType.getKey(entity.getType()).toString().equals(killObjective.getEntityKey())
+                && doesTagContainTag(entity.saveWithoutId(new CompoundTag()), killObjective.getEntityTag());
       }
       case DeliverToEntity -> {
         QuestObjectiveTypes.DeliverToEntityObjective deliverToEntityObjective = (QuestObjectiveTypes.DeliverToEntityObjective) objective;

--- a/src/main/java/flash/npcmod/network/packets/client/CBuildQuest.java
+++ b/src/main/java/flash/npcmod/network/packets/client/CBuildQuest.java
@@ -5,6 +5,7 @@ import flash.npcmod.core.quests.Quest;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.TextComponent;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.network.NetworkEvent;
 
 import java.util.function.Supplier;
@@ -35,14 +36,17 @@ public class CBuildQuest {
 
   public static void handle(CBuildQuest msg, Supplier<NetworkEvent.Context> ctx) {
     ctx.get().enqueueWork(() -> {
-      if (ctx.get().getSender().hasPermissions(4)) {
+      ServerPlayer sender = ctx.get().getSender();
+      if (sender.hasPermissions(4)) {
         CommonQuestUtil.buildQuest(msg.name, msg.jsonText);
 
         Quest quest = CommonQuestUtil.loadQuestFile(msg.name);
-        if (quest != null)
-          ctx.get().getSender().displayClientMessage(new TextComponent("Successfully built quest \'" + msg.name + "\'").withStyle(ChatFormatting.GREEN), false);
-        else
-          ctx.get().getSender().displayClientMessage(new TextComponent("Couldn't build quest \'" + msg.name + "\'").withStyle(ChatFormatting.RED), false);
+        if (quest != null) {
+          sender.displayClientMessage(new TextComponent("Successfully built quest '" + msg.name + "'").withStyle(ChatFormatting.GREEN), false);
+
+        } else {
+          sender.displayClientMessage(new TextComponent("Couldn't build quest '" + msg.name + "'").withStyle(ChatFormatting.RED), false);
+        }
       }
     });
     ctx.get().setPacketHandled(true);

--- a/src/main/java/flash/npcmod/network/packets/client/CRequestQuestInfo.java
+++ b/src/main/java/flash/npcmod/network/packets/client/CRequestQuestInfo.java
@@ -31,7 +31,7 @@ public class CRequestQuestInfo {
     ctx.get().enqueueWork(() -> {
       ServerPlayer sender = ctx.get().getSender();
 
-      JsonObject quest = CommonQuestUtil.loadQuest(msg.name);
+      JsonObject quest = CommonQuestUtil.loadQuestAsJson(msg.name);
 
       if (quest != null) {
         PacketDispatcher.sendTo(new SSendQuestInfo(msg.name, quest.toString()), sender);

--- a/src/main/java/flash/npcmod/network/packets/server/SSendQuestInfo.java
+++ b/src/main/java/flash/npcmod/network/packets/server/SSendQuestInfo.java
@@ -1,6 +1,6 @@
 package flash.npcmod.network.packets.server;
 
-import flash.npcmod.core.quests.CommonQuestUtil;
+import flash.npcmod.Main;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraftforge.network.NetworkEvent;
 
@@ -27,7 +27,7 @@ public class SSendQuestInfo {
 
   public static void handle(SSendQuestInfo msg, Supplier<NetworkEvent.Context> ctx) {
     ctx.get().enqueueWork(() -> {
-      CommonQuestUtil.buildQuest(msg.name, msg.questInfo);
+      Main.PROXY.getQuestInfo(msg.name, msg.questInfo);
     });
     ctx.get().setPacketHandled(true);
   }


### PR DESCRIPTION
- `moveOnTag` and `moveOnTeam` functions
- function debug mode with command to toggle it
- usage of `\n` in dialogues
- fixed functions not loading on world load after adding global files
- fixed dialogue node search sometimes not finding the correct node
- fixed npc functions not using the npc as command source
- fixed breaking of text colour of dialogues sometimes breaking
- fixed quests not reloading for the client on edit or `/flashnpcs quests reload`
- fixed ESC key closing the entire gui when editing a node in a `TreeBuilderScreen`